### PR TITLE
Remove unnecessary prompt caching from example message

### DIFF
--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -417,8 +417,7 @@ class CodeActAgent(Agent):
             messages.append(
                 Message(
                     role='user',
-                    content=[TextContent(text=example_message)],
-                    cache_prompt=self.llm.is_caching_prompt_active(),
+                    content=[TextContent(text=example_message)]
                 )
             )
 


### PR DESCRIPTION
The example message is not used with Anthropic models, which are the only models that support prompt caching. Therefore, setting `cache_prompt` on the example message was unnecessary.

This change removes the `cache_prompt` parameter from the example message, making the caching points clearer and more accurate:
1. One cache point for the system message (at start)
2. Three more cache points from the reversed messages loop for user/tool messages

This gives us exactly 4 cache points total, which is what we want for Anthropic models.