### PR TITLE
feat: Add lil-opus planning resolver design

### DIFF
--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -38,7 +38,7 @@ B. **Not Suitable - Needs Response**
   - Bug report missing critical information
   - Feature request without clear scope
 - Action: 
-  - Comment explaining unsuitability for automation
+  - Comment asking for the needed information, to let Pet Sonnet know what to do
   - Provide template/guidance for needed information
 
 C. **Potentially Suitable - Needs Clarification**

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -67,8 +67,17 @@ D. **Suitable - Proceed to Planning**
 (To be expanded with our discussion)
 
 ## Open Questions
-1. Should the planning stage be interactive?
-2. Where and how should planning artifacts be stored?
+
+### Answered
+1. ✓ Should the planning stage be interactive?
+   - No, the planning stage should be non-interactive
+   
+2. ✓ Where and how should planning artifacts be stored?
+   - In `.openhands/microagents/` directory
+   - Following the microagent pattern with YAML frontmatter
+   - Same location can be used by lil-opus for storing issue-specific plans
+
+### Still To Address
 3. How should edge cases between suitability categories be handled?
 4. What should be the specific criteria for each category?
 5. What should the response templates look like?

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -33,24 +33,17 @@ A. **Not Suitable - No Response Needed**
   - Already resolved/duplicate
 - Action: Silently exit workflow
 
-B. **Not Suitable - Needs Response**
+B. **Needs More Information**
 - Characteristics:
-  - Bug report missing critical information
+  - Bug report missing information (critical or specific details)
   - Feature request without clear scope
-- Action: 
-  - Comment asking for the needed information, to let Pet Sonnet know what to do
-  - Provide template/guidance for needed information
-
-C. **Potentially Suitable - Needs Clarification**
-- Characteristics:
-  - Mostly complete bug report missing specific detail
-  - Clear issue but ambiguous success criteria
   - Reproducible problem with unclear expected behavior
 - Action:
-  - Comment with specific clarifying questions
-  - Suggest rephrasing for automation-friendliness
+  - Comment asking for the specific information needed
+  - Provide guidance on what details would help automation
+  - Let Pet Sonnet know what information to look for
 
-D. **Suitable - Proceed to Planning**
+C. **Suitable - Proceed to Planning**
 - Characteristics:
   - Clear bug report with reproducible steps
   - Well-defined scope
@@ -73,18 +66,18 @@ When someone asks for your help (through @lil-opus or fix-me-opus), first check:
 If you decide to help, think about whether this is something that would work well with automation:
 - 👍 Great fits:
   - Clear bug reports with steps to reproduce
-  - Well-defined feature requests
-  - Issues with clear success criteria
+  - Well-defined feature requests with clear scope
+  - Issues where you understand what needs to be done
 
-- 🤔 Maybe, with some clarification:
-  - Bug reports missing a few details
-  - Issues that are clear but need success criteria defined
-  - You can ask for specific clarifications if you think it would help!
+- 🤔 Needs more information:
+  - Bug reports missing details (critical or specific)
+  - Feature requests needing scope clarification
+  - You can ask for what you need to understand the task!
 
-- 👎 Probably not great for automation:
+- 👎 Not suitable for automation:
   - Pure discussions or questions
   - Issues needing significant human judgment
-  - Missing critical information
+  - Already resolved or duplicate issues
 
 Remember:
 - You don't need to strictly categorize everything

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -23,7 +23,6 @@ Before evaluating the issue content, the workflow first validates the trigger so
 2. **Unauthorized Triggers**:
    - Triggers from accounts not in the approved list
    - Action: Silently exit workflow without response
-   - Rationale: Security and resource management
 
 #### Content Suitability Categories:
 

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -61,7 +61,46 @@ D. **Suitable - Proceed to Planning**
   - Proceed to detailed planning phase
 
 ### 2. Planning Phase
-(To be expanded with our discussion)
+
+#### Initial Prompt for lil-opus
+Hey there! You're lil-opus, a friendly planning assistant for the OpenHands resolver. Your job is to look at issues and PRs and figure out if and how they should be handled by the main resolver.
+
+Here are some guidelines to help you think about it, but trust your judgment - you're smart and can handle nuanced situations!
+
+When someone asks for your help (through @lil-opus or fix-me-opus), first check:
+1. Is this someone you should respond to?
+   - If it's @enyst or someone from the approved list, definitely help!
+   - If not, it's best to quietly step back without responding
+
+If you decide to help, think about whether this is something that would work well with automation:
+- 👍 Great fits:
+  - Clear bug reports with steps to reproduce
+  - Well-defined feature requests
+  - Issues with clear success criteria
+
+- 🤔 Maybe, with some clarification:
+  - Bug reports missing a few details
+  - Issues that are clear but need success criteria defined
+  - You can ask for specific clarifications if you think it would help!
+
+- 👎 Probably not great for automation:
+  - Pure discussions or questions
+  - Issues needing significant human judgment
+  - Missing critical information
+
+Remember:
+- You don't need to strictly categorize everything
+- Use these as guidelines, not rules
+- If something feels "in-between", go with what makes sense
+- Be helpful but also be honest when automation might not be the best approach
+
+Your main tasks are to:
+1. Decide if this is something for the resolver
+2. If yes, create a plan for how to approach it
+3. Craft a specific prompt for the main resolver
+4. If no, decide whether and how to respond
+
+How does that sound? Let me know what you think!
 
 ### 3. Handoff to Main Resolver
 (To be expanded with our discussion)
@@ -83,12 +122,19 @@ D. **Suitable - Proceed to Planning**
    - Categories serve as guidelines, not strict boundaries
    - Claude is good at handling nuanced cases
 
-### Still To Address
-4. What should be the specific criteria for each category?
-5. What should the response templates look like?
+### Answered
+4. ✓ What should be the specific criteria for each category?
+   - Provided as friendly guidelines in the prompt
+   - Let the LLM use them flexibly
+   - Focus on clear examples rather than strict rules
+
+5. ✓ What should the response templates look like?
+   - Let the LLM generate natural responses
+   - Provided guidance on when to respond vs stay quiet
+   - Focus on being helpful and honest
 
 ## Next Steps
-- Define specific criteria for each suitability category
-- Design response templates
-- Plan the detailed planning phase workflow
 - Design the handoff mechanism to the main resolver
+- Implement the workflow in GitHub Actions
+- Test with some sample issues
+- Create configuration for approved users list

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -91,7 +91,6 @@ Your main tasks are to:
 3. Craft a specific prompt for the main resolver
 4. If no, decide whether and how to respond
 
-How does that sound? Let me know what you think!
 
 ### 3. Handoff to Main Resolver
 (To be expanded with our discussion)

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -37,7 +37,6 @@ B. **Not Suitable - Needs Response**
 - Characteristics:
   - Bug report missing critical information
   - Feature request without clear scope
-  - Issue requiring human decision-making
 - Action: 
   - Comment explaining unsuitability for automation
   - Provide template/guidance for needed information

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -43,13 +43,13 @@ B. **Needs More Information**
   - Provide guidance on what details would help automation
   - Let Pet Sonnet know what information to look for
 
-C. **Suitable - Proceed to Planning**
-- Characteristics:
-  - Clear bug report with reproducible steps
-  - Well-defined scope
-  - Clear success criteria
+C. **Default - Proceed to Planning**
+- This is the default path if authorization passes
 - Action:
-  - Proceed to detailed planning phase
+  - Create a plan and proceed to detailed planning phase
+- Only fall back to other categories if:
+  - The issue is clearly not suitable for automation (category A)
+  - Or critical information is missing (category B)
 
 ### 2. Planning Phase
 
@@ -63,11 +63,7 @@ When someone asks for your help (through @lil-opus or fix-me-opus), first check:
    - If it's @enyst or someone from the approved list, definitely help!
    - If not, it's best to quietly step back without responding
 
-If you decide to help, think about whether this is something that would work well with automation:
-- 👍 Great fits:
-  - Clear bug reports with steps to reproduce
-  - Well-defined feature requests with clear scope
-  - Issues where you understand what needs to be done
+If you decide to help, your default approach should be to try to create a plan. Only fall back to these cases if needed:
 
 - 🤔 Needs more information:
   - Bug reports missing details (critical or specific)
@@ -78,6 +74,8 @@ If you decide to help, think about whether this is something that would work wel
   - Pure discussions or questions
   - Issues needing significant human judgment
   - Already resolved or duplicate issues
+
+Remember that most issues can be attempted - don't be too strict in filtering them out!
 
 Remember:
 - You don't need to strictly categorize everything

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -77,8 +77,13 @@ D. **Suitable - Proceed to Planning**
    - Following the microagent pattern with YAML frontmatter
    - Same location can be used by lil-opus for storing issue-specific plans
 
+### Answered
+3. ✓ How should edge cases between suitability categories be handled?
+   - Let the LLM make the judgment call
+   - Categories serve as guidelines, not strict boundaries
+   - Claude is good at handling nuanced cases
+
 ### Still To Address
-3. How should edge cases between suitability categories be handled?
 4. What should be the specific criteria for each category?
 5. What should the response templates look like?
 

--- a/.openhands/microagents/lil-opus.md
+++ b/.openhands/microagents/lil-opus.md
@@ -1,3 +1,8 @@
+---
+name: lil-opus
+agent: CodeAct
+---
+
 # Opus Planning Resolver Design Document
 
 ## Overview

--- a/openhands/resolver/OPUS_PLANNING.md
+++ b/openhands/resolver/OPUS_PLANNING.md
@@ -7,7 +7,20 @@ This document outlines the design for a new two-stage resolver workflow triggere
 
 ### 1. Initial Assessment Phase
 
-#### Suitability Categories:
+#### Pre-Assessment: Trigger Authorization
+Before evaluating the issue content, the workflow first validates the trigger source:
+
+1. **Authorized Triggers**:
+   - Direct triggers from specific accounts (e.g., @enyst)
+   - Triggers from accounts in an approved list
+   - Action: Proceed to content assessment
+
+2. **Unauthorized Triggers**:
+   - Triggers from accounts not in the approved list
+   - Action: Silently exit workflow without response
+   - Rationale: Security and resource management
+
+#### Content Suitability Categories:
 
 A. **Not Suitable - No Response Needed**
 - Characteristics:

--- a/openhands/resolver/OPUS_PLANNING.md
+++ b/openhands/resolver/OPUS_PLANNING.md
@@ -1,0 +1,62 @@
+# Opus Planning Resolver Design Document
+
+## Overview
+This document outlines the design for a new two-stage resolver workflow triggered by `@lil-opus` mentions or `fix-me-opus` labels. The workflow first performs a planning stage to assess and plan the resolution before optionally triggering the main resolver.
+
+## Workflow Stages
+
+### 1. Initial Assessment Phase
+
+#### Suitability Categories:
+
+A. **Not Suitable - No Response Needed**
+- Characteristics:
+  - Issue is purely discussion-based
+  - Question that should be redirected to discussions
+  - Already resolved/duplicate
+- Action: Silently exit workflow
+
+B. **Not Suitable - Needs Response**
+- Characteristics:
+  - Bug report missing critical information
+  - Feature request without clear scope
+  - Issue requiring human decision-making
+- Action: 
+  - Comment explaining unsuitability for automation
+  - Provide template/guidance for needed information
+
+C. **Potentially Suitable - Needs Clarification**
+- Characteristics:
+  - Mostly complete bug report missing specific detail
+  - Clear issue but ambiguous success criteria
+  - Reproducible problem with unclear expected behavior
+- Action:
+  - Comment with specific clarifying questions
+  - Suggest rephrasing for automation-friendliness
+
+D. **Suitable - Proceed to Planning**
+- Characteristics:
+  - Clear bug report with reproducible steps
+  - Well-defined scope
+  - Clear success criteria
+- Action:
+  - Proceed to detailed planning phase
+
+### 2. Planning Phase
+(To be expanded with our discussion)
+
+### 3. Handoff to Main Resolver
+(To be expanded with our discussion)
+
+## Open Questions
+1. Should the planning stage be interactive?
+2. Where and how should planning artifacts be stored?
+3. How should edge cases between suitability categories be handled?
+4. What should be the specific criteria for each category?
+5. What should the response templates look like?
+
+## Next Steps
+- Define specific criteria for each suitability category
+- Design response templates
+- Plan the detailed planning phase workflow
+- Design the handoff mechanism to the main resolver


### PR DESCRIPTION
This PR adds the initial design document for the lil-opus planning resolver, which will act as a planning stage before the main resolver.

Key features:
- Authorization checks for triggers
- Flexible issue/PR assessment guidelines
- Friendly, conversational prompt for the LLM
- Storage location in .openhands/microagents/