### PR TITLE
Fix runtime_hosts type conversion in RecallObservation

### DIFF
--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -2,6 +2,8 @@ from openhands.events.observation.agent import (
     AgentCondensationObservation,
     AgentStateChangedObservation,
     AgentThinkObservation,
+    RecallObservation,
+    RecallType,
 )
 from openhands.events.observation.browse import BrowserOutputObservation
 from openhands.events.observation.commands import (
@@ -40,4 +42,6 @@ __all__ = [
     'SuccessObservation',
     'UserRejectObservation',
     'AgentCondensationObservation',
+    'RecallObservation',
+    'RecallType',
 ]

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -389,15 +389,11 @@ class ConversationMemory:
                     if obs.repo_name or obs.repo_directory
                     else None
                 )
-                runtime_info = None
-                if obs.runtime_hosts:
-                    # Convert to dict[str, int] if it's a list
-                    if isinstance(obs.runtime_hosts, list):
-                        # Default to port 12000 for each host
-                        hosts_dict = {host: 12000 for host in obs.runtime_hosts}
-                        runtime_info = RuntimeInfo(available_hosts=hosts_dict)
-                    else:
-                        runtime_info = RuntimeInfo(available_hosts=obs.runtime_hosts)
+                runtime_info = (
+                    RuntimeInfo(available_hosts=obs.runtime_hosts)
+                    if obs.runtime_hosts
+                    else None
+                )
                 repo_instructions = (
                     obs.repo_instructions if obs.repo_instructions else ''
                 )

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -389,11 +389,15 @@ class ConversationMemory:
                     if obs.repo_name or obs.repo_directory
                     else None
                 )
-                runtime_info = (
-                    RuntimeInfo(available_hosts=obs.runtime_hosts)
-                    if obs.runtime_hosts
-                    else None
-                )
+                runtime_info = None
+                if obs.runtime_hosts:
+                    # Convert to dict[str, int] if it's a list
+                    if isinstance(obs.runtime_hosts, list):
+                        # Default to port 12000 for each host
+                        hosts_dict = {host: 12000 for host in obs.runtime_hosts}
+                        runtime_info = RuntimeInfo(available_hosts=hosts_dict)
+                    else:
+                        runtime_info = RuntimeInfo(available_hosts=obs.runtime_hosts)
                 repo_instructions = (
                     obs.repo_instructions if obs.repo_instructions else ''
                 )

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -11,7 +11,12 @@ from openhands.microagent.microagent import RepoMicroAgent
 
 @dataclass
 class RuntimeInfo:
-    available_hosts: dict[str, int]
+    available_hosts: dict[str, int] | list[str]
+
+    def __post_init__(self):
+        # Convert list[str] to dict[str, int] if needed
+        if isinstance(self.available_hosts, list):
+            self.available_hosts = {host: 12000 for host in self.available_hosts}
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes a type mismatch issue in the `conversation_memory.py` file where the `runtime_hosts` field in `RecallObservation` could be either a `dict[str, int]` or a `list[str]`, but the `RuntimeInfo` class expected only `dict[str, int]`.

Changes made:

1. Added a type check to handle both formats
2. If `runtime_hosts` is a list, convert it to a dictionary with default port 12000 for each host
3. If `runtime_hosts` is already a dictionary, use it directly

This ensures compatibility with both formats while maintaining type safety. All tests pass, including mypy type checking.