### PR TITLE
Fix RecallObservation tests to match implementation field names

### DIFF
--- a/tests/unit/test_observation_serialization.py
+++ b/tests/unit/test_observation_serialization.py
@@ -5,9 +5,8 @@ from openhands.events.observation import (
     CmdOutputObservation,
     FileEditObservation,
     Observation,
-    RecallObservation,
-    RecallType,
 )
+from openhands.events.observation.agent import RecallObservation, RecallType
 from openhands.events.serialization import (
     event_from_dict,
     event_to_dict,
@@ -243,24 +242,65 @@ def test_file_edit_observation_legacy_serialization():
 
 
 def test_recall_observation_serialization():
+    """Test serialization of a basic RecallObservation."""
+    # Create original dictionary with Event base class fields
     original_observation_dict = {
+        'id': 123,
+        'timestamp': '2023-05-15T10:30:00',
+        'source': 'environment',
         'observation': 'recall',
+        'content': 'Recall information',
         'extras': {
-            'recall_type': RecallType.ENVIRONMENT_INFO,
+            'recall_type': RecallType.ENVIRONMENT_INFO.value,
             'repo_name': 'some_repo_name',
             'repo_directory': 'some_repo_directory',
             'runtime_hosts': ['host1', 'host2'],
             'repo_instructions': 'complex_repo_instructions',
         },
     }
-    serialization_deserialization(original_observation_dict, RecallObservation)
+    
+    # Convert to object
+    observation_instance = event_from_dict(original_observation_dict)
+    
+    # Verify object properties including Event base class properties
+    assert isinstance(observation_instance, RecallObservation)
+    assert observation_instance.id == 123
+    assert observation_instance.timestamp == '2023-05-15T10:30:00'
+    assert observation_instance.source.value == 'environment'
+    assert observation_instance.content == 'Recall information'
+    assert observation_instance.recall_type == RecallType.ENVIRONMENT_INFO
+    assert observation_instance.repo_name == 'some_repo_name'
+    assert observation_instance.repo_directory == 'some_repo_directory'
+    assert observation_instance.runtime_hosts == ['host1', 'host2']
+    assert observation_instance.repo_instructions == 'complex_repo_instructions'
+    
+    # Convert back to dict
+    serialized = event_to_dict(observation_instance)
+    
+    # Verify serialized structure including Event base class fields
+    assert serialized['id'] == 123
+    assert serialized['timestamp'] == '2023-05-15T10:30:00'
+    assert serialized['source'] == 'environment'
+    assert serialized['content'] == 'Recall information'
+    assert serialized['observation'] == 'recall'
+    assert serialized['extras']['recall_type'] == RecallType.ENVIRONMENT_INFO.value
+    assert serialized['extras']['repo_name'] == 'some_repo_name'
+    assert serialized['extras']['repo_directory'] == 'some_repo_directory'
+    assert serialized['extras']['runtime_hosts'] == ['host1', 'host2']
+    assert serialized['extras']['repo_instructions'] == 'complex_repo_instructions'
 
 
 def test_recall_observation_microagent_knowledge_serialization():
+    """Test serialization of a RecallObservation with microagent knowledge."""
+    # Create original dictionary with Event base class fields
     original_observation_dict = {
+        'id': 456,
+        'timestamp': '2023-06-20T14:45:00',
+        'source': 'agent',
         'observation': 'recall',
+        'content': 'Microagent knowledge recall',
         'extras': {
-            'recall_type': RecallType.MICROAGENT_KNOWLEDGE,
+            'recall_type': RecallType.KNOWLEDGE_MICROAGENT.value,
             'microagent_knowledge': [
                 {
                     'agent_name': 'microagent1',
@@ -275,16 +315,45 @@ def test_recall_observation_microagent_knowledge_serialization():
             ],
         },
     }
-    serialization_deserialization(original_observation_dict, RecallObservation)
+    
+    # Convert to object
+    observation_instance = event_from_dict(original_observation_dict)
+    
+    # Verify object properties including Event base class properties
+    assert isinstance(observation_instance, RecallObservation)
+    assert observation_instance.id == 456
+    assert observation_instance.timestamp == '2023-06-20T14:45:00'
+    assert observation_instance.source.value == 'agent'
+    assert observation_instance.content == 'Microagent knowledge recall'
+    assert observation_instance.recall_type == RecallType.KNOWLEDGE_MICROAGENT
+    assert len(observation_instance.microagent_knowledge) == 2
+    assert observation_instance.microagent_knowledge[0]['agent_name'] == 'microagent1'
+    assert observation_instance.microagent_knowledge[0]['trigger_word'] == 'trigger_word1'
+    assert observation_instance.microagent_knowledge[0]['content'] == 'content1'
+    
+    # Convert back to dict
+    serialized = event_to_dict(observation_instance)
+    
+    # Verify serialized structure including Event base class fields
+    assert serialized['id'] == 456
+    assert serialized['timestamp'] == '2023-06-20T14:45:00'
+    assert serialized['source'] == 'agent'
+    assert serialized['content'] == 'Microagent knowledge recall'
+    assert serialized['observation'] == 'recall'
+    assert serialized['extras']['recall_type'] == RecallType.KNOWLEDGE_MICROAGENT.value
+    assert len(serialized['extras']['microagent_knowledge']) == 2
+    assert serialized['extras']['microagent_knowledge'][0]['agent_name'] == 'microagent1'
+    assert serialized['extras']['microagent_knowledge'][0]['trigger_word'] == 'trigger_word1'
+    assert serialized['extras']['microagent_knowledge'][0]['content'] == 'content1'
 
 
 def test_recall_observation_knowledge_microagent_serialization():
     """Test serialization of a RecallObservation with KNOWLEDGE_MICROAGENT type."""
-    # Create a RecallObservation with triggered microagent content
+    # Create a RecallObservation with microagent knowledge
     original = RecallObservation(
         content='Knowledge microagent information',
         recall_type=RecallType.KNOWLEDGE_MICROAGENT,
-        triggered_content=[
+        microagent_knowledge=[
             {
                 'agent_name': 'python_best_practices',
                 'trigger_word': 'python',
@@ -305,22 +374,22 @@ def test_recall_observation_knowledge_microagent_serialization():
     assert serialized['observation'] == ObservationType.RECALL
     assert serialized['content'] == 'Knowledge microagent information'
     assert serialized['extras']['recall_type'] == RecallType.KNOWLEDGE_MICROAGENT.value
-    assert len(serialized['extras']['triggered_content']) == 2
-    assert serialized['extras']['triggered_content'][0]['trigger_word'] == 'python'
+    assert len(serialized['extras']['microagent_knowledge']) == 2
+    assert serialized['extras']['microagent_knowledge'][0]['trigger_word'] == 'python'
 
     # Deserialize back to RecallObservation
     deserialized = observation_from_dict(serialized)
 
     # Verify properties are preserved
     assert deserialized.recall_type == RecallType.KNOWLEDGE_MICROAGENT
-    assert deserialized.triggered_content == original.triggered_content
+    assert deserialized.microagent_knowledge == original.microagent_knowledge
     assert deserialized.content == original.content
 
-    # Check that environment info fields are None
-    assert deserialized.repository_name is None
-    assert deserialized.repository_directory is None
-    assert deserialized.repository_instructions is None
-    assert deserialized.runtime_hosts is None
+    # Check that environment info fields are empty
+    assert deserialized.repo_name == ''
+    assert deserialized.repo_directory == ''
+    assert deserialized.repo_instructions == ''
+    assert deserialized.runtime_hosts == {}
 
 
 def test_recall_observation_environment_info_serialization():
@@ -329,9 +398,9 @@ def test_recall_observation_environment_info_serialization():
     original = RecallObservation(
         content='Environment information',
         recall_type=RecallType.ENVIRONMENT_INFO,
-        repository_name='OpenHands',
-        repository_directory='/workspace/openhands',
-        repository_instructions="Follow the project's coding style guide.",
+        repo_name='OpenHands',
+        repo_directory='/workspace/openhands',
+        repo_instructions="Follow the project's coding style guide.",
         runtime_hosts={'127.0.0.1': 8080, 'localhost': 5000},
     )
 
@@ -342,7 +411,7 @@ def test_recall_observation_environment_info_serialization():
     assert serialized['observation'] == ObservationType.RECALL
     assert serialized['content'] == 'Environment information'
     assert serialized['extras']['recall_type'] == RecallType.ENVIRONMENT_INFO.value
-    assert serialized['extras']['repository_name'] == 'OpenHands'
+    assert serialized['extras']['repo_name'] == 'OpenHands'
     assert serialized['extras']['runtime_hosts'] == {
         '127.0.0.1': 8080,
         'localhost': 5000,
@@ -353,13 +422,14 @@ def test_recall_observation_environment_info_serialization():
 
     # Verify properties are preserved
     assert deserialized.recall_type == RecallType.ENVIRONMENT_INFO
-    assert deserialized.repository_name == original.repository_name
-    assert deserialized.repository_directory == original.repository_directory
-    assert deserialized.repository_instructions == original.repository_instructions
+    assert deserialized.repo_name == original.repo_name
+    assert deserialized.repo_directory == original.repo_directory
+    assert deserialized.repo_instructions == original.repo_instructions
     assert deserialized.runtime_hosts == original.runtime_hosts
+    assert deserialized.content == original.content
 
-    # Check that knowledge microagent fields are None
-    assert deserialized.triggered_content is None
+    # Check that knowledge microagent fields are empty
+    assert deserialized.microagent_knowledge == []
 
 
 def test_recall_observation_combined_serialization():
@@ -371,12 +441,12 @@ def test_recall_observation_combined_serialization():
         content='Combined information',
         recall_type=RecallType.ENVIRONMENT_INFO,
         # Environment info
-        repository_name='OpenHands',
-        repository_directory='/workspace/openhands',
-        repository_instructions="Follow the project's coding style guide.",
+        repo_name='OpenHands',
+        repo_directory='/workspace/openhands',
+        repo_instructions="Follow the project's coding style guide.",
         runtime_hosts={'127.0.0.1': 8080},
         # Knowledge microagent info
-        triggered_content=[
+        microagent_knowledge=[
             {
                 'agent_name': 'python_best_practices',
                 'trigger_word': 'python',
@@ -390,9 +460,9 @@ def test_recall_observation_combined_serialization():
 
     # Verify serialized data has both types of fields
     assert serialized['extras']['recall_type'] == RecallType.ENVIRONMENT_INFO.value
-    assert serialized['extras']['repository_name'] == 'OpenHands'
+    assert serialized['extras']['repo_name'] == 'OpenHands'
     assert (
-        serialized['extras']['triggered_content'][0]['agent_name']
+        serialized['extras']['microagent_knowledge'][0]['agent_name']
         == 'python_best_practices'
     )
 
@@ -403,10 +473,10 @@ def test_recall_observation_combined_serialization():
     assert deserialized.recall_type == RecallType.ENVIRONMENT_INFO
 
     # Environment properties
-    assert deserialized.repository_name == original.repository_name
-    assert deserialized.repository_directory == original.repository_directory
-    assert deserialized.repository_instructions == original.repository_instructions
+    assert deserialized.repo_name == original.repo_name
+    assert deserialized.repo_directory == original.repo_directory
+    assert deserialized.repo_instructions == original.repo_instructions
     assert deserialized.runtime_hosts == original.runtime_hosts
-
+    
     # Knowledge microagent properties
-    assert deserialized.triggered_content == original.triggered_content
+    assert deserialized.microagent_knowledge == original.microagent_knowledge


### PR DESCRIPTION
This PR fixes the RecallObservation tests in test_observation_serialization.py to match the actual implementation field names. The tests were failing due to field name mismatches between the tests and the actual implementation.

Changes made:
1. Updated field names in the tests to match the implementation:
   - `repository_name` → `repo_name`
   - `repository_directory` → `repo_directory`
   - `repository_instructions` → `repo_instructions`
   - `triggered_content` → `microagent_knowledge`

2. Fixed enum value references:
   - `RecallType.MICROAGENT_KNOWLEDGE` → `RecallType.KNOWLEDGE_MICROAGENT`

3. Updated assertions to check for empty default values instead of None

All tests are now passing.