### PR TITLE
ci: Skip VSCode extension build during Windows tests

### DIFF
--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -56,6 +56,8 @@ jobs:
   test-on-windows:
     name: Python Tests on Windows
     runs-on: windows-latest
+    env:
+      SKIP_VSCODE_BUILD: "true"
     strategy:
       matrix:
         python-version: ['3.12']


### PR DESCRIPTION
This prevents build.py from attempting to build the VSCode extension during the Windows CI tests, which may resolve issues with Node.js/npm not being available or correctly configured in that environment.

Note: Windows compatibility is with local runtime.