### PR TITLE
Weekly OpenAPI drift check via OpenHands Cloud

### DIFF
--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -17,23 +17,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check required secrets
+        env:
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
         shell: bash
         run: |
           set -euo pipefail
           missing=0
-          for v in OPENHANDS_CLOUD_API_KEY LLM_API_KEY; do
-            if [ -z "${{ secrets[format('{0}', v)] }}" ]; then
-              echo "Error: Required secret $v is not set." >&2
-              missing=1
-            fi
-          done
+          if [ -z "${OPENHANDS_CLOUD_API_KEY:-}" ]; then
+            echo "Error: Required secret OPENHANDS_CLOUD_API_KEY is not set." >&2
+            missing=1
+          fi
+          if [ -z "${LLM_API_KEY:-}" ]; then
+            echo "Error: Required secret LLM_API_KEY is not set." >&2
+            missing=1
+          fi
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
-          if [ -z "${{ secrets.LLM_MODEL }}" ]; then
+          if [ -z "${LLM_MODEL:-}" ]; then
             echo "Warning: LLM_MODEL not set, Cloud will use default model if applicable."
           fi
-          if [ -z "${{ secrets.LLM_BASE_URL }}" ]; then
+          if [ -z "${LLM_BASE_URL:-}" ]; then
             echo "Warning: LLM_BASE_URL not set, using provider default endpoint."
           fi
 

--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check required secrets
         env:
-          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
@@ -26,8 +26,8 @@ jobs:
         run: |
           set -euo pipefail
           missing=0
-          if [ -z "${OPENHANDS_CLOUD_API_KEY:-}" ]; then
-            echo "Error: Required secret OPENHANDS_CLOUD_API_KEY is not set." >&2
+          if [ -z "${OPENHANDS_API_KEY:-}" ]; then
+            echo "Error: Required secret OPENHANDS_API_KEY is not set." >&2
             missing=1
           fi
           if [ -z "${LLM_API_KEY:-}" ]; then
@@ -46,7 +46,7 @@ jobs:
 
       - name: Configure LLM settings in OpenHands Cloud
         env:
-          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
@@ -59,14 +59,14 @@ jobs:
             --arg base  "${LLM_BASE_URL:-}" \
             '{ llm_model: ($model|select(. != "")), llm_api_key: $key, llm_base_url: ($base|select(. != "")) }')
           curl -sS -X POST "$CLOUD_API_URL/api/settings" \
-            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" \
+            -H "Authorization: Bearer $OPENHANDS_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$payload" | jq .
 
       - name: Start OpenHands Cloud conversation
         id: start
         env:
-          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -104,7 +104,7 @@ jobs:
 
           data=$(jq -n --arg msg "$PROMPT" --arg repo "${GITHUB_REPOSITORY}" '{ initial_user_msg: $msg, repository: $repo }')
           resp=$(curl -sS -X POST "$CLOUD_API_URL/api/conversations" \
-            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" \
+            -H "Authorization: Bearer $OPENHANDS_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$data")
           echo "$resp" | jq .
@@ -114,7 +114,7 @@ jobs:
 
       - name: Wait for conversation to complete
         env:
-          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -123,7 +123,7 @@ jobs:
           # Wait up to ~120 minutes (240 * 30s)
           for i in $(seq 1 240); do
             status=$(curl -sS -X GET "$CLOUD_API_URL/api/conversations/$cid" \
-              -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" | jq -r '.status')
+              -H "Authorization: Bearer $OPENHANDS_API_KEY" | jq -r '.status')
             echo "Status: $status"
             if [ "$status" != "RUNNING" ]; then
               break
@@ -134,13 +134,13 @@ jobs:
       - name: Fetch events and extract report
         id: extract
         env:
-          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
           cid="${{ steps.start.outputs.cid }}"
           resp=$(curl -sS "$CLOUD_API_URL/api/conversations/$cid/events?start_id=0&limit=5000" \
-            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY")
+            -H "Authorization: Bearer $OPENHANDS_API_KEY")
           echo "$resp" > events.json
           # Collect assistant messages into a flat file
           echo "$resp" | jq -r '.events[] | select(.role=="assistant" or .role=="system" or .role=="tool").content // empty' > msgs.txt || true

--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 6 * * 6" # Every Saturday at 06:00 UTC
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: ''
 
 permissions:
   contents: write

--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -1,0 +1,168 @@
+name: Weekly OpenAPI drift via OpenHands Cloud
+
+on:
+  schedule:
+    - cron: "0 6 * * 6" # Every Saturday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CLOUD_API_URL: ${{ secrets.CLOUD_API_URL || 'https://app.all-hands.dev' }}
+
+jobs:
+  openapi-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for v in OPENHANDS_CLOUD_API_KEY LLM_API_KEY; do
+            if [ -z "${{ secrets[format('{0}', v)] }}" ]; then
+              echo "Error: Required secret $v is not set." >&2
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          if [ -z "${{ secrets.LLM_MODEL }}" ]; then
+            echo "Warning: LLM_MODEL not set, Cloud will use default model if applicable."
+          fi
+          if [ -z "${{ secrets.LLM_BASE_URL }}" ]; then
+            echo "Warning: LLM_BASE_URL not set, using provider default endpoint."
+          fi
+
+      - name: Configure LLM settings in OpenHands Cloud
+        env:
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload=$(jq -n \
+            --arg model "${LLM_MODEL:-}" \
+            --arg key   "${LLM_API_KEY}" \
+            --arg base  "${LLM_BASE_URL:-}" \
+            '{ llm_model: ($model|select(. != "")), llm_api_key: $key, llm_base_url: ($base|select(. != "")) }')
+          curl -sS -X POST "$CLOUD_API_URL/api/settings" \
+            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$payload" | jq .
+
+      - name: Start OpenHands Cloud conversation
+        id: start
+        env:
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read -r -d '' PROMPT << 'EOF'
+          You are the OpenHands agent running against the repository provided below.
+          Task objective:
+          - Run the repository script: python scripts/update_openapi.py --check --output-report openapi_diff.md --output-json openapi_diff.json
+          - If the script is missing, perform the following fallback:
+            * Import the FastAPI app from openhands.server.app (variable name: app) and generate the live OpenAPI via app.openapi().
+            * Load the repository's documented OpenAPI from docs/openapi.json.
+            * Apply the same path-exclusion logic specified by scripts/update_openapi.py if present. If not present, use a conservative default exclude list for purely-internal or health endpoints (e.g., /alive, /health, /server_info, /mcp/**, /api/options/**). The script, if present, has the final authority for exclusions.
+            * Compute a structured diff: added/removed/changed paths/methods, and salient schema differences, focusing on changes that would affect API consumers.
+            * Write outputs to openapi_diff.json (structured) and openapi_diff.md (human-readable summary).
+          - Review the diff and determine if any differences require changes for API users (e.g., documented routes missing/incorrect vs server, breaking response shape changes, or authentication/required parameter changes). If yes:
+            * Create a new git branch (e.g., chore/openapi-drift-<YYYYMMDD>), make minimal changes to fix the discrepancies (typically docs/openapi.json and related docs such as docs/usage/cloud/cloud-api.mdx). If server is incorrect, propose minimal server fixes.
+            * Commit with a clear message like: "chore(docs): sync OpenAPI spec with server (weekly drift)".
+            * Open a Draft Pull Request against the default branch. Ensure the PR follows the repository's PR template by reading the template file(s):
+              - Prefer .github/pull_request_template.md if present; otherwise, check common locations like .github/PULL_REQUEST_TEMPLATE/*.md.
+              - Include the template content at the top of the PR body.
+              - Immediately after the template content, add a personalized description that begins with: "openhands agent:" and then summarize the drift and the changes you made.
+            * If push/PR permissions are unavailable in this environment, prepare a patch and include exact commands for a maintainer to push the branch and open a draft PR, and include those in the report.
+          - Always print a final delimited report so the workflow can parse it. The report must include:
+            === OPENAPI_DIFF_REPORT_START ===
+            Executive Summary ...
+            (Include the contents of openapi_diff.md if it exists)
+            drift_detected: true|false
+            pr_url: <PR URL if created or empty>
+            pr_number: <PR number if created or empty>
+            === OPENAPI_DIFF_REPORT_END ===
+          Notes:
+          - Work only within this repository context.
+          - Do NOT expose or print any secrets.
+          EOF
+
+          data=$(jq -n --arg msg "$PROMPT" --arg repo "${GITHUB_REPOSITORY}" '{ initial_user_msg: $msg, repository: $repo }')
+          resp=$(curl -sS -X POST "$CLOUD_API_URL/api/conversations" \
+            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$data")
+          echo "$resp" | jq .
+          cid=$(echo "$resp" | jq -r '.conversation_id // .id')
+          echo "cid=$cid" >> "$GITHUB_OUTPUT"
+          echo "conversation_url=$CLOUD_API_URL/conversations/$cid" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for conversation to complete
+        env:
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cid="${{ steps.start.outputs.cid }}"
+          echo "Conversation: $cid"
+          # Wait up to ~120 minutes (240 * 30s)
+          for i in $(seq 1 240); do
+            status=$(curl -sS -X GET "$CLOUD_API_URL/api/conversations/$cid" \
+              -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY" | jq -r '.status')
+            echo "Status: $status"
+            if [ "$status" != "RUNNING" ]; then
+              break
+            fi
+            sleep 30
+          done
+
+      - name: Fetch events and extract report
+        id: extract
+        env:
+          OPENHANDS_CLOUD_API_KEY: ${{ secrets.OPENHANDS_CLOUD_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cid="${{ steps.start.outputs.cid }}"
+          resp=$(curl -sS "$CLOUD_API_URL/api/conversations/$cid/events?start_id=0&limit=5000" \
+            -H "Authorization: Bearer $OPENHANDS_CLOUD_API_KEY")
+          echo "$resp" > events.json
+          # Collect assistant messages into a flat file
+          echo "$resp" | jq -r '.events[] | select(.role=="assistant" or .role=="system" or .role=="tool").content // empty' > msgs.txt || true
+          awk '/=== OPENAPI_DIFF_REPORT_START ===/{flag=1;next}/=== OPENAPI_DIFF_REPORT_END ===/{flag=0}flag' msgs.txt > openapi_diff_report.md || true
+          if [ ! -s openapi_diff_report.md ]; then
+            echo "Report not found in events. Failing." >&2
+            exit 1
+          fi
+          # Parse drift and PR info (best-effort)
+          drift=$(grep -Eo 'drift_detected:[[:space:]]*(true|false)' openapi_diff_report.md | tail -n1 | awk -F: '{gsub(/ /, "", $2); print tolower($2)}')
+          pr_url=$(grep -Eo 'pr_url:[[:space:]]*[^ ]+' openapi_diff_report.md | tail -n1 | awk -F: '{sub(/^ /, "", $2); print $2}')
+          pr_number=$(grep -Eo 'pr_number:[[:space:]]*[0-9]+' openapi_diff_report.md | tail -n1 | awk -F: '{sub(/^ /, "", $2); print $2}')
+          echo "drift=${drift:-false}" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${pr_url:-}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${pr_number:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-diff-report
+          path: |
+            openapi_diff_report.md
+            events.json
+
+      - name: Summarize
+        shell: bash
+        run: |
+          echo "Conversation: ${{ steps.start.outputs.conversation_url }}"
+          echo "Drift detected: ${{ steps.extract.outputs.drift }}"
+          if [ -n "${{ steps.extract.outputs.pr_url }}" ]; then
+            echo "Proposed PR (draft): ${{ steps.extract.outputs.pr_url }}"
+          fi


### PR DESCRIPTION
This adds a scheduled workflow that runs weekly and uses OpenHands Cloud API to:

- Configure LLM settings (LLM_MODEL, LLM_API_KEY, LLM_BASE_URL)
- Start an OpenHands Cloud conversation against this repo
- Run scripts/update_openapi.py (with a robust fallback) to compare the FastAPI-derived OpenAPI schema vs docs/openapi.json
- If consumer-impacting changes are detected, the agent is instructed to open a Draft PR and follow the repo PR template. The personalized description starts with: "openhands agent:".
- Always emits a delimited report block in workflow logs that’s uploaded as an artifact

Secrets required:
- OPENHANDS_CLOUD_API_KEY (required)
- LLM_API_KEY (required)
- LLM_MODEL (optional)
- LLM_BASE_URL (optional)
- CLOUD_API_URL (optional, defaults to https://app.all-hands.dev)

You can test via workflow_dispatch.

Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev