### PR TITLE
chore(workflow): weekly-openapi uses only OPENHANDS_API_KEY; robust auth check

### DIFF
--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -38,9 +38,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Ensure auth is valid
-          curl -sS -X GET "$CLOUD_API_URL/api/server_info" \
-            -H "Authorization: Bearer $OPENHANDS_API_KEY" | jq .
+          # Only ensure auth is valid; do not set provider-specific LLM secrets here.
+          status=$(curl -sS -o resp.txt -w '%{http_code}' \
+            -H "Authorization: Bearer $OPENHANDS_API_KEY" \
+            -H "Accept: application/json" \
+            "$CLOUD_API_URL/api/server_info")
+          echo "HTTP status: $status"
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "Auth check failed with HTTP $status" >&2
+            head -c 400 resp.txt >&2 || true
+            exit 1
+          fi
+          # Try to pretty-print JSON; if not JSON, print raw for visibility
+          if jq -e . >/dev/null 2>&1 < resp.txt; then
+            jq . < resp.txt
+          else
+            echo "Non-JSON response:"; sed -n '1,200p' resp.txt
+          fi
 
       - name: Start OpenHands Cloud conversation
         id: start


### PR DESCRIPTION
This PR streamlines the weekly OpenAPI drift workflow to rely only on the OpenHands Cloud API key and hardens the authentication check to handle non-JSON responses.

Summary of changes
- Remove LLM secrets from .github/workflows/weekly-openapi-drift.yml (LLM_API_KEY, LLM_MODEL, LLM_BASE_URL)
- Replace settings POST with minimal auth GET /server_info
- Robust auth check: capture HTTP status and body, pretty-print JSON if valid; otherwise display raw content

Why
- Our weekly drift workflow configures the Cloud session using only OPENHANDS_API_KEY. Provider-specific LLM settings are already configured in the Cloud account and do not need to be passed as GitHub secrets.
- The previous step piped server_info directly to jq which failed when the endpoint returned non-JSON (e.g., errors). This change prevents jq parse errors and provides clear diagnostic output.

Files touched
- .github/workflows/weekly-openapi-drift.yml

Notes
- No changes to other workflows that intentionally use LLM_* (e.g., integration-runner.yml, openhands-resolver.yml, e2e-tests.yml).

Co-authored-by: OpenHands-GPT-5 <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c934f2e2ad76444e956b0cf2c59f8016)