### PR TITLE
feat: clean Python-centric cron agents for weekly automation

### DIFF
--- a/.github/workflows/weekly-architecture-audit.yml
+++ b/.github/workflows/weekly-architecture-audit.yml
@@ -1,0 +1,50 @@
+name: Weekly Architecture Audit
+
+on:
+  schedule:
+    - cron: "0 6 * * 6"  # Every Saturday at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  architecture-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests jinja2
+
+      - name: Run architecture audit
+        env:
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
+        run: |
+          cd scripts
+          python cron_agents.py architecture-audit \
+            --api-key "$OPENHANDS_API_KEY" \
+            --repository "${{ github.repository }}" \
+            --branch "main" \
+            --output ../architecture_audit_result.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: architecture-audit-results
+          path: architecture_audit_result.json

--- a/.github/workflows/weekly-openapi-drift.yml
+++ b/.github/workflows/weekly-openapi-drift.yml
@@ -1,0 +1,50 @@
+name: Weekly OpenAPI Drift Check
+
+on:
+  schedule:
+    - cron: "0 6 * * 6"  # Every Saturday at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  openapi-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests jinja2
+
+      - name: Run OpenAPI drift check
+        env:
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
+        run: |
+          cd scripts
+          python cron_agents.py openapi-drift \
+            --api-key "$OPENHANDS_API_KEY" \
+            --repository "${{ github.repository }}" \
+            --branch "main" \
+            --output ../openapi_drift_result.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: openapi-drift-results
+          path: openapi_drift_result.json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,105 @@
+# OpenHands Cron Agents
+
+This directory contains the implementation of automated weekly tasks using OpenHands Cloud API.
+
+## Structure
+
+```
+scripts/
+├── cloud_api.py           # Clean OpenHands Cloud API client
+├── cron_agents.py         # Main task functions with CLI
+├── prompts/               # Jinja2 prompt templates
+│   ├── architecture_audit.j2
+│   └── openapi_drift.j2
+└── README.md             # This file
+```
+
+## Components
+
+### `cloud_api.py`
+Clean, reusable OpenHands Cloud API client with:
+- Structured error handling with `CloudAPIError`
+- Authentication testing
+- Conversation management
+- Event polling with progress callbacks
+- Comprehensive timeout and error recovery
+
+### `cron_agents.py`
+Main module containing two weekly task functions:
+
+1. **`run_architecture_audit()`** - Reviews architecture documentation
+2. **`run_openapi_drift_check()`** - Detects OpenAPI schema drift
+
+Both functions return structured results with success/error information.
+
+### `prompts/`
+Jinja2 templates for task prompts:
+- `architecture_audit.j2` - Architecture documentation review prompt
+- `openapi_drift.j2` - OpenAPI drift detection prompt with structured reporting
+
+## Usage
+
+### CLI Interface
+
+```bash
+# Architecture audit
+python cron_agents.py architecture-audit \
+  --api-key "$OPENHANDS_API_KEY" \
+  --repository "owner/repo" \
+  --branch "main" \
+  --output results.json
+
+# OpenAPI drift check
+python cron_agents.py openapi-drift \
+  --api-key "$OPENHANDS_API_KEY" \
+  --repository "owner/repo" \
+  --branch "main" \
+  --output results.json
+```
+
+### Programmatic Usage
+
+```python
+from cron_agents import run_architecture_audit, run_openapi_drift_check
+
+# Run architecture audit
+result = run_architecture_audit(
+    api_key="your-api-key",
+    repository="owner/repo",
+    branch="main"
+)
+
+if result["success"]:
+    print(f"Audit completed: {result['conversation_url']}")
+else:
+    print(f"Audit failed: {result['error']}")
+```
+
+## GitHub Workflows
+
+Two minimal workflows are provided:
+- `.github/workflows/weekly-architecture-audit.yml`
+- `.github/workflows/weekly-openapi-drift.yml`
+
+Both run weekly and only require the `OPENHANDS_API_KEY` secret.
+
+## Error Handling
+
+The implementation provides comprehensive error reporting:
+- HTTP status codes and response details for API errors
+- Structured error messages with context
+- Progress logging during polling
+- Timeout handling with graceful degradation
+
+## Security Model
+
+- Only requires `OPENHANDS_API_KEY` in CI/workflows
+- LLM provider settings managed in OpenHands Cloud account
+- No sensitive data logged or exposed
+- Clean separation between authentication and task logic
+
+## Dependencies
+
+- `requests` - HTTP client for API calls
+- `jinja2` - Template rendering for prompts
+- Standard library modules: `json`, `logging`, `pathlib`, `re`, `time`

--- a/scripts/cloud_api.py
+++ b/scripts/cloud_api.py
@@ -1,0 +1,183 @@
+"""
+OpenHands Cloud API client.
+
+Clean, minimal Python wrapper around OpenHands Cloud endpoints.
+Handles authentication and provides structured error reporting.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+DEFAULT_BASE_URL = 'https://app.all-hands.dev'
+
+
+class CloudAPIError(Exception):
+    """Exception raised for Cloud API errors."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        response_text: str | None = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_text = response_text
+
+
+@dataclass
+class OpenHandsCloudClient:
+    """OpenHands Cloud API client with clean error handling."""
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    timeout: int = 60
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+        }
+
+    def _handle_response(self, response: requests.Response) -> dict[str, Any]:
+        """Handle API response with structured error reporting."""
+        try:
+            response.raise_for_status()
+            return response.json() if response.content else {}
+        except requests.HTTPError as e:
+            error_msg = f'HTTP {response.status_code}: {e}'
+            try:
+                error_data = response.json()
+                if isinstance(error_data, dict) and 'detail' in error_data:
+                    error_msg += f' - {error_data["detail"]}'
+            except Exception:
+                # If we can't parse JSON, include raw response text
+                error_msg += f' - {response.text[:500]}'
+
+            raise CloudAPIError(
+                error_msg, status_code=response.status_code, response_text=response.text
+            ) from e
+        except requests.RequestException as e:
+            raise CloudAPIError(f'Request failed: {e}') from e
+
+    def test_auth(self) -> dict[str, Any]:
+        """Test authentication by calling server_info endpoint."""
+        url = f'{self.base_url}/api/server_info'
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
+        return self._handle_response(response)
+
+    def create_conversation(
+        self,
+        *,
+        initial_user_msg: str,
+        repository: str | None = None,
+        selected_branch: str | None = None,
+        conversation_instructions: str | None = None,
+        git_provider: str | None = None,
+        image_urls: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new conversation."""
+        url = f'{self.base_url}/api/conversations'
+        body: dict[str, Any] = {'initial_user_msg': initial_user_msg}
+
+        optional_params = {
+            'repository': repository,
+            'git_provider': git_provider,
+            'selected_branch': selected_branch,
+            'conversation_instructions': conversation_instructions,
+            'image_urls': image_urls,
+        }
+        body.update({k: v for k, v in optional_params.items() if v})
+
+        response = requests.post(
+            url, headers=self._headers(), json=body, timeout=self.timeout
+        )
+        return self._handle_response(response)
+
+    def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        """Get conversation details."""
+        url = f'{self.base_url}/api/conversations/{conversation_id}'
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
+        return self._handle_response(response)
+
+    def get_conversation_events(
+        self, conversation_id: str, start_id: int = 0, limit: int = 1000
+    ) -> dict[str, Any]:
+        """Get conversation events."""
+        url = f'{self.base_url}/api/conversations/{conversation_id}/events'
+        params = {'start_id': start_id, 'limit': limit}
+        response = requests.get(
+            url, headers=self._headers(), params=params, timeout=self.timeout
+        )
+        return self._handle_response(response)
+
+    def poll_until_complete(
+        self,
+        conversation_id: str,
+        *,
+        timeout_s: int = 1800,  # 30 minutes
+        poll_interval_s: int = 15,
+        terminal_statuses: tuple[str, ...] = (
+            'COMPLETED',
+            'FAILED',
+            'STOPPED',
+            'PAUSED',
+        ),
+        progress_callback: callable | None = None,
+    ) -> str:
+        """
+        Poll conversation until a terminal status is reached or timeout.
+
+        Args:
+            conversation_id: The conversation ID to poll
+            timeout_s: Maximum time to wait in seconds
+            poll_interval_s: Time between polls in seconds
+            terminal_statuses: Status values that indicate completion
+            progress_callback: Optional callback function called with (status, elapsed_time)
+
+        Returns:
+            Final status string
+
+        Raises:
+            CloudAPIError: If polling fails or times out
+        """
+        deadline = time.time() + timeout_s
+        start_time = time.time()
+        last_status = ''
+
+        while time.time() < deadline:
+            try:
+                info = self.get_conversation(conversation_id)
+                status = str(info.get('status') or info.get('Status') or '').upper()
+
+                if status:
+                    last_status = status
+
+                elapsed = time.time() - start_time
+                if progress_callback:
+                    progress_callback(status, elapsed)
+
+                if status in terminal_statuses:
+                    return status
+
+            except CloudAPIError as e:
+                # Log the error but continue polling unless it's a permanent failure
+                if e.status_code and e.status_code < 500:
+                    # Client error - likely permanent, stop polling
+                    raise
+                # Server error - continue polling
+                if progress_callback:
+                    progress_callback(f'ERROR: {e}', time.time() - start_time)
+
+            time.sleep(poll_interval_s)
+
+        # Timeout reached
+        elapsed = time.time() - start_time
+        raise CloudAPIError(
+            f'Polling timeout after {elapsed:.1f}s. Last status: {last_status}'
+        )

--- a/scripts/cloud_api.py
+++ b/scripts/cloud_api.py
@@ -116,6 +116,12 @@ class OpenHandsCloudClient:
         )
         return self._handle_response(response)
 
+    def get_trajectory(self, conversation_id: str) -> dict[str, Any]:
+        """Get conversation trajectory (full event history)."""
+        url = f'{self.base_url}/api/conversations/{conversation_id}/trajectory'
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
+        return self._handle_response(response)
+
     def poll_until_complete(
         self,
         conversation_id: str,

--- a/scripts/cloud_api.py
+++ b/scripts/cloud_api.py
@@ -121,12 +121,9 @@ class OpenHandsCloudClient:
         conversation_id: str,
         *,
         timeout_s: int = 1800,  # 30 minutes
-        poll_interval_s: int = 15,
+        poll_interval_s: int = 300,  # 5 minutes
         terminal_statuses: tuple[str, ...] = (
-            'COMPLETED',
-            'FAILED',
-            'STOPPED',
-            'PAUSED',
+            'STOPPED',  # Conversation finished (success or failure)
         ),
         progress_callback: callable | None = None,
     ) -> str:
@@ -153,7 +150,8 @@ class OpenHandsCloudClient:
         while time.time() < deadline:
             try:
                 info = self.get_conversation(conversation_id)
-                status = str(info.get('status') or info.get('Status') or '').upper()
+                # Status comes from ConversationStatus enum in the API response
+                status = str(info.get('status', '')).upper()
 
                 if status:
                     last_status = status

--- a/scripts/cron_agents.py
+++ b/scripts/cron_agents.py
@@ -1,0 +1,375 @@
+"""
+OpenHands Cron Agents - Weekly automated tasks using OpenHands Cloud.
+
+This module contains the main functions for running weekly automated tasks:
+1. Architecture documentation audit
+2. OpenAPI drift detection
+
+Each function handles the complete workflow: prompt rendering, conversation creation,
+polling, and result extraction with comprehensive error reporting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import jinja2
+from cloud_api import CloudAPIError, OpenHandsCloudClient
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def load_prompt_template(template_name: str, **kwargs) -> str:
+    """Load and render a Jinja2 prompt template."""
+    try:
+        script_dir = Path(__file__).parent
+        template_path = script_dir / 'prompts' / f'{template_name}.j2'
+
+        if not template_path.exists():
+            raise FileNotFoundError(f'Template not found: {template_path}')
+
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template_content = f.read()
+
+        template = jinja2.Template(template_content)
+        return template.render(**kwargs)
+
+    except Exception as e:
+        logger.error(f'Failed to load template {template_name}: {e}')
+        raise
+
+
+def extract_report_from_events(
+    events_data: dict[str, Any], report_markers: tuple[str, str]
+) -> str | None:
+    """Extract delimited report from conversation events."""
+    try:
+        start_marker, end_marker = report_markers
+
+        # Collect all assistant/system/tool messages
+        messages = []
+        for event in events_data.get('events', []):
+            if event.get('role') in ('assistant', 'system', 'tool'):
+                content = event.get('content', '')
+                if content:
+                    messages.append(content)
+
+        # Join all messages and look for report
+        full_text = '\n'.join(messages)
+
+        # Extract report between markers
+        pattern = f'{re.escape(start_marker)}(.*?){re.escape(end_marker)}'
+        match = re.search(pattern, full_text, re.DOTALL)
+
+        if match:
+            return match.group(1).strip()
+
+        logger.warning('Report markers not found in conversation events')
+        return None
+
+    except Exception as e:
+        logger.error(f'Failed to extract report from events: {e}')
+        return None
+
+
+def progress_callback(status: str, elapsed_time: float) -> None:
+    """Progress callback for polling."""
+    logger.info(f'Status: {status} (elapsed: {elapsed_time:.1f}s)')
+
+
+def run_architecture_audit(
+    api_key: str,
+    repository: str,
+    branch: str = 'main',
+    base_url: str = 'https://app.all-hands.dev',
+    poll_timeout: int = 1800,
+) -> dict[str, Any]:
+    """
+    Run weekly architecture documentation audit.
+
+    Returns:
+        Dict with keys: success, conversation_id, conversation_url, status, report, error
+    """
+    result = {
+        'success': False,
+        'conversation_id': None,
+        'conversation_url': None,
+        'status': None,
+        'report': None,
+        'error': None,
+    }
+
+    try:
+        logger.info(f'Starting architecture audit for {repository}:{branch}')
+
+        # Initialize client
+        client = OpenHandsCloudClient(api_key=api_key, base_url=base_url)
+
+        # Test authentication
+        logger.info('Testing authentication...')
+        client.test_auth()
+        logger.info('Authentication successful')
+
+        # Load and render prompt
+        logger.info('Loading prompt template...')
+        prompt = load_prompt_template(
+            'architecture_audit', repository=repository, branch=branch
+        )
+
+        # Create conversation
+        logger.info('Creating conversation...')
+        conv_response = client.create_conversation(
+            initial_user_msg=prompt,
+            repository=repository,
+            selected_branch=branch,
+            conversation_instructions='Focus on architecture documentation accuracy. Only make changes if material discrepancies are found.',
+        )
+
+        conversation_id = conv_response.get('conversation_id') or conv_response.get(
+            'id'
+        )
+        if not conversation_id:
+            raise CloudAPIError('No conversation ID returned from API')
+
+        result['conversation_id'] = conversation_id
+        result['conversation_url'] = f'{base_url}/conversations/{conversation_id}'
+
+        logger.info(f'Conversation created: {result["conversation_url"]}')
+
+        # Poll for completion
+        logger.info('Polling for completion...')
+        final_status = client.poll_until_complete(
+            conversation_id, timeout_s=poll_timeout, progress_callback=progress_callback
+        )
+
+        result['status'] = final_status
+        logger.info(f'Conversation completed with status: {final_status}')
+
+        # Get events and extract any findings
+        logger.info('Fetching conversation events...')
+        events = client.get_conversation_events(conversation_id, limit=5000)
+
+        # For architecture audit, we don't have specific report markers,
+        # so we'll just collect the last few assistant messages as summary
+        assistant_messages = []
+        for event in events.get('events', []):
+            if event.get('role') == 'assistant':
+                content = event.get('content', '')
+                if content:
+                    assistant_messages.append(content)
+
+        if assistant_messages:
+            # Take the last few messages as the summary
+            result['report'] = '\n\n'.join(assistant_messages[-3:])
+
+        result['success'] = True
+        logger.info('Architecture audit completed successfully')
+
+    except Exception as e:
+        error_msg = f'Architecture audit failed: {e}'
+        logger.error(error_msg)
+        result['error'] = error_msg
+
+        # Include more details for CloudAPIError
+        if isinstance(e, CloudAPIError):
+            if e.status_code:
+                result['error'] += f' (HTTP {e.status_code})'
+            if e.response_text:
+                result['error'] += f'\nResponse: {e.response_text[:500]}'
+
+    return result
+
+
+def run_openapi_drift_check(
+    api_key: str,
+    repository: str,
+    branch: str = 'main',
+    base_url: str = 'https://app.all-hands.dev',
+    poll_timeout: int = 1800,
+) -> dict[str, Any]:
+    """
+    Run weekly OpenAPI drift detection.
+
+    Returns:
+        Dict with keys: success, conversation_id, conversation_url, status, report,
+                       drift_detected, pr_url, pr_number, error
+    """
+    result = {
+        'success': False,
+        'conversation_id': None,
+        'conversation_url': None,
+        'status': None,
+        'report': None,
+        'drift_detected': False,
+        'pr_url': None,
+        'pr_number': None,
+        'error': None,
+    }
+
+    try:
+        logger.info(f'Starting OpenAPI drift check for {repository}:{branch}')
+
+        # Initialize client
+        client = OpenHandsCloudClient(api_key=api_key, base_url=base_url)
+
+        # Test authentication
+        logger.info('Testing authentication...')
+        client.test_auth()
+        logger.info('Authentication successful')
+
+        # Load and render prompt
+        logger.info('Loading prompt template...')
+        date_suffix = datetime.now().strftime('%Y%m%d')
+        prompt = load_prompt_template(
+            'openapi_drift',
+            repository=repository,
+            branch=branch,
+            date_suffix=date_suffix,
+            drift_detected=False,  # Template placeholder
+            pr_url='',  # Template placeholder
+            pr_number='',  # Template placeholder
+        )
+
+        # Create conversation
+        logger.info('Creating conversation...')
+        conv_response = client.create_conversation(
+            initial_user_msg=prompt,
+            repository=repository,
+            selected_branch=branch,
+            conversation_instructions='Focus on OpenAPI drift detection. Only create PRs for consumer-impacting changes.',
+        )
+
+        conversation_id = conv_response.get('conversation_id') or conv_response.get(
+            'id'
+        )
+        if not conversation_id:
+            raise CloudAPIError('No conversation ID returned from API')
+
+        result['conversation_id'] = conversation_id
+        result['conversation_url'] = f'{base_url}/conversations/{conversation_id}'
+
+        logger.info(f'Conversation created: {result["conversation_url"]}')
+
+        # Poll for completion
+        logger.info('Polling for completion...')
+        final_status = client.poll_until_complete(
+            conversation_id, timeout_s=poll_timeout, progress_callback=progress_callback
+        )
+
+        result['status'] = final_status
+        logger.info(f'Conversation completed with status: {final_status}')
+
+        # Get events and extract report
+        logger.info('Fetching conversation events...')
+        events = client.get_conversation_events(conversation_id, limit=5000)
+
+        # Extract the delimited report
+        report = extract_report_from_events(
+            events,
+            ('=== OPENAPI_DIFF_REPORT_START ===', '=== OPENAPI_DIFF_REPORT_END ==='),
+        )
+
+        if report:
+            result['report'] = report
+
+            # Parse structured fields from report
+            drift_match = re.search(
+                r'drift_detected:\s*(true|false)', report, re.IGNORECASE
+            )
+            if drift_match:
+                result['drift_detected'] = drift_match.group(1).lower() == 'true'
+
+            pr_url_match = re.search(r'pr_url:\s*(\S+)', report)
+            if pr_url_match and pr_url_match.group(1) not in ('', 'empty'):
+                result['pr_url'] = pr_url_match.group(1)
+
+            pr_number_match = re.search(r'pr_number:\s*(\d+)', report)
+            if pr_number_match:
+                result['pr_number'] = pr_number_match.group(1)
+        else:
+            logger.warning('No structured report found in conversation')
+
+        result['success'] = True
+        logger.info('OpenAPI drift check completed successfully')
+
+    except Exception as e:
+        error_msg = f'OpenAPI drift check failed: {e}'
+        logger.error(error_msg)
+        result['error'] = error_msg
+
+        # Include more details for CloudAPIError
+        if isinstance(e, CloudAPIError):
+            if e.status_code:
+                result['error'] += f' (HTTP {e.status_code})'
+            if e.response_text:
+                result['error'] += f'\nResponse: {e.response_text[:500]}'
+
+    return result
+
+
+def main():
+    """CLI interface for running cron agents."""
+    parser = argparse.ArgumentParser(description='OpenHands Cron Agents')
+    parser.add_argument(
+        'task', choices=['architecture-audit', 'openapi-drift'], help='Task to run'
+    )
+    parser.add_argument('--api-key', required=True, help='OpenHands Cloud API key')
+    parser.add_argument('--repository', required=True, help='Repository (owner/repo)')
+    parser.add_argument('--branch', default='main', help='Branch to work on')
+    parser.add_argument(
+        '--base-url', default='https://app.all-hands.dev', help='Cloud API base URL'
+    )
+    parser.add_argument(
+        '--timeout', type=int, default=1800, help='Polling timeout in seconds'
+    )
+    parser.add_argument('--output', help='Output file for results (JSON)')
+
+    args = parser.parse_args()
+
+    # Run the appropriate task
+    if args.task == 'architecture-audit':
+        result = run_architecture_audit(
+            api_key=args.api_key,
+            repository=args.repository,
+            branch=args.branch,
+            base_url=args.base_url,
+            poll_timeout=args.timeout,
+        )
+    elif args.task == 'openapi-drift':
+        result = run_openapi_drift_check(
+            api_key=args.api_key,
+            repository=args.repository,
+            branch=args.branch,
+            base_url=args.base_url,
+            poll_timeout=args.timeout,
+        )
+    else:
+        logger.error(f'Unknown task: {args.task}')
+        sys.exit(1)
+
+    # Output results
+    print(json.dumps(result, indent=2))
+
+    # Save to file if requested
+    if args.output:
+        with open(args.output, 'w') as f:
+            json.dump(result, f, indent=2)
+        logger.info(f'Results saved to {args.output}')
+
+    # Exit with appropriate code
+    sys.exit(0 if result['success'] else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prompts/architecture_audit.j2
+++ b/scripts/prompts/architecture_audit.j2
@@ -1,0 +1,18 @@
+You are an AI software engineer working in this repository. Task:
+
+1) Review docs/usage/architecture/backend.mdx and docs/usage/architecture/runtime.mdx.
+2) Compare to the current codebase (esp. openhands/ and runtime code).
+3) If material changes occurred since last week:
+   - Update the docs accurately; keep edits minimal and factual with references.
+   - If diagrams are out of date and simple to refresh, update or add a precise TODO.
+   - Open a PR following .github/pull_request_template.md with a clear technical report.
+4) If nothing meaningful changed, do NOT open a PR; summarize findings in the conversation.
+
+Rules:
+- Only modify architecture docs unless necessary.
+- Make smallest correct changes; keep style consistent.
+- If opening a PR, follow the PR template and include a technical report.
+- If no meaningful change, summarize findings only (no PR).
+
+Repository: {{ repository }}
+Branch: {{ branch }}

--- a/scripts/prompts/openapi_drift.j2
+++ b/scripts/prompts/openapi_drift.j2
@@ -1,0 +1,33 @@
+You are the OpenHands agent running against the repository provided below.
+
+Task objective:
+- Run the repository script: python scripts/update_openapi.py --check --output-report openapi_diff.md --output-json openapi_diff.json
+- If the script is missing, perform the following fallback:
+  * Import the FastAPI app from openhands.server.app (variable name: app) and generate the live OpenAPI via app.openapi().
+  * Load the repository's documented OpenAPI from docs/openapi.json.
+  * Apply the same path-exclusion logic specified by scripts/update_openapi.py if present. If not present, use a conservative default exclude list for purely-internal or health endpoints (e.g., /alive, /health, /server_info, /mcp/**, /api/options/**). The script, if present, has the final authority for exclusions.
+  * Compute a structured diff: added/removed/changed paths/methods, and salient schema differences, focusing on changes that would affect API consumers.
+  * Write outputs to openapi_diff.json (structured) and openapi_diff.md (human-readable summary).
+- Review the diff and determine if any differences require changes for API users (e.g., documented routes missing/incorrect vs server, breaking response shape changes, or authentication/required parameter changes). If yes:
+  * Create a new git branch (e.g., chore/openapi-drift-{{ date_suffix }}), make minimal changes to fix the discrepancies (typically docs/openapi.json and related docs such as docs/usage/cloud/cloud-api.mdx). If server is incorrect, propose minimal server fixes.
+  * Commit with a clear message like: "chore(docs): sync OpenAPI spec with server (weekly drift)".
+  * Open a Draft Pull Request against the default branch. Ensure the PR follows the repository's PR template by reading the template file(s):
+    - Prefer .github/pull_request_template.md if present; otherwise, check common locations like .github/PULL_REQUEST_TEMPLATE/*.md.
+    - Include the template content at the top of the PR body.
+    - Immediately after the template content, add a personalized description that begins with: "openhands agent:" and then summarize the drift and the changes you made.
+  * If push/PR permissions are unavailable in this environment, prepare a patch and include exact commands for a maintainer to push the branch and open a draft PR, and include those in the report.
+- Always print a final delimited report so the workflow can parse it. The report must include:
+  === OPENAPI_DIFF_REPORT_START ===
+  Executive Summary ...
+  (Include the contents of openapi_diff.md if it exists)
+  drift_detected: {{ "true" if drift_detected else "false" }}
+  pr_url: {{ pr_url or "" }}
+  pr_number: {{ pr_number or "" }}
+  === OPENAPI_DIFF_REPORT_END ===
+
+Notes:
+- Work only within this repository context.
+- Do NOT expose or print any secrets.
+
+Repository: {{ repository }}
+Branch: {{ branch }}


### PR DESCRIPTION
This PR introduces a clean, Python-centric approach to weekly automated tasks using OpenHands Cloud API, consolidating the best practices from previous PRs #88, #89, #91, and #92.

## What's New

### 🏗️ **Clean Architecture**
- **`scripts/cloud_api.py`**: Reusable OpenHands Cloud API client with structured error handling
- **`scripts/cron_agents.py`**: Main module with two weekly task functions + CLI interface
- **`scripts/prompts/`**: Jinja2 templates for maintainable prompt management
- **Minimal workflows**: Only essential YAML, most logic in Python

### 🤖 **Two Weekly Tasks**
1. **Architecture Audit** (`run_architecture_audit()`)
   - Reviews `docs/usage/architecture/backend.mdx` and `runtime.mdx`
   - Only opens PRs if material changes are detected
   
2. **OpenAPI Drift Check** (`run_openapi_drift_check()`)
   - Detects schema drift between server and docs
   - Structured reporting with delimited output parsing

### 🔒 **Security Model**
- Only requires `OPENHANDS_API_KEY` in CI
- LLM provider settings managed in Cloud account
- No sensitive data in workflows or logs

### 🛠️ **Developer Experience**
- **CLI Interface**: `python cron_agents.py {architecture-audit,openapi-drift} --api-key ... --repository ...`
- **Programmatic Usage**: Import functions directly
- **Comprehensive Error Reporting**: Exact error details with HTTP status codes
- **Progress Logging**: Real-time status updates during polling

## Key Improvements Over Previous PRs

| Feature | Previous PRs | This PR |
|---------|-------------|----------|
| **Code Organization** | Mixed YAML/Python | Python-centric with minimal YAML |
| **Error Handling** | Basic | Structured with `CloudAPIError` class |
| **Prompt Management** | Inline strings | Jinja2 templates in separate files |
| **Reusability** | Workflow-specific | Clean API client + task functions |
| **Testing** | Limited | CLI interface + programmatic usage |
| **Dependencies** | Various | Minimal: `requests`, `jinja2` |

## Files Added

```
scripts/
├── cloud_api.py              # Clean Cloud API client
├── cron_agents.py            # Main task functions + CLI
├── prompts/                  # Jinja2 prompt templates
│   ├── architecture_audit.j2
│   └── openapi_drift.j2
└── README.md                 # Comprehensive documentation

.github/workflows/
├── weekly-architecture-audit.yml    # Minimal workflow
└── weekly-openapi-drift.yml         # Minimal workflow
```

## Usage Examples

### CLI Usage
```bash
# Architecture audit
python scripts/cron_agents.py architecture-audit \
  --api-key "$OPENHANDS_API_KEY" \
  --repository "owner/repo" \
  --output results.json

# OpenAPI drift check  
python scripts/cron_agents.py openapi-drift \
  --api-key "$OPENHANDS_API_KEY" \
  --repository "owner/repo" \
  --output results.json
```

### Programmatic Usage
```python
from scripts.cron_agents import run_architecture_audit

result = run_architecture_audit(
    api_key="your-key",
    repository="owner/repo"
)

if result["success"]:
    print(f"Conversation: {result['conversation_url']}") 
else:
    print(f"Error: {result['error']}") 
```

## Testing Strategy

This implementation is designed for testing in the playground repository before proposing upstream. The clean separation of concerns makes it easy to:

- Test individual components (API client, task functions, templates)
- Mock API responses for unit testing
- Run workflows manually via `workflow_dispatch`
- Validate error handling scenarios

## Next Steps

1. **Test in playground**: Validate workflows and error handling
2. **Iterate on prompts**: Refine templates based on actual results  
3. **Add monitoring**: Consider metrics/alerting for production use
4. **Upstream proposal**: Once stable, propose to main OpenHands repo

---

**Dependencies**: `requests`, `jinja2`  
**Secrets Required**: `OPENHANDS_API_KEY`  
**Schedule**: Saturdays 06:00 UTC  

Co-authored-by: openhands <openhands@all-hands.dev>