### PR TITLE
Add OpenHands issue duplicate automation workflow

### DIFF
--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -3,6 +3,8 @@ name: Issue Duplicate Check via OpenHands Cloud
 on:
   issues:
     types: [opened]
+  schedule:
+    - cron: '0 9 * * *'
   workflow_dispatch:
     inputs:
       mode:
@@ -12,6 +14,7 @@ on:
         options:
           - smoke-clone
           - issue-check
+          - auto-close
         default: smoke-clone
       issue_number:
         description: Existing issue number to analyze when mode is issue-check
@@ -22,6 +25,12 @@ on:
         required: false
         type: string
         default: enyst/playground
+      close_after_days:
+        description: Days to wait before auto-closing duplicate candidates in auto-close mode
+        required: false
+        type: string
+        default: '3'
+
 
 permissions:
   contents: read
@@ -104,14 +113,22 @@ jobs:
               with output_path.open('a', encoding='utf-8') as fh:
                   fh.write(f"{name}<<EOF\n{value}\nEOF\n")
 
+          canonical_issue_number = result.get('canonical_issue_number')
           with output_path.open('a', encoding='utf-8') as fh:
+              fh.write(f"should_comment={'true' if result.get('should_comment') else 'false'}\n")
               fh.write(f"is_duplicate={'true' if result.get('is_duplicate') else 'false'}\n")
+              fh.write(
+                  f"auto_close_candidate={'true' if result.get('auto_close_candidate') else 'false'}\n"
+              )
               fh.write(f"confidence={result.get('confidence', '')}\n")
+              fh.write(f"classification={result.get('classification', '')}\n")
+              fh.write(
+                  f"canonical_issue_number={canonical_issue_number if canonical_issue_number is not None else ''}\n"
+              )
               fh.write(f"conversation_url={result.get('conversation_url', '')}\n")
               fh.write(f"app_conversation_id={result.get('app_conversation_id', '')}\n")
 
           write_multiline('summary', str(result.get('summary', '')).strip())
-          write_multiline('comment_body', str(result.get('comment_body', '')).strip())
           write_multiline(
               'candidate_issues_json',
               json.dumps(result.get('candidate_issues', []), ensure_ascii=False),
@@ -120,7 +137,7 @@ jobs:
           candidate_lines = []
           for candidate in result.get('candidate_issues', []):
               candidate_lines.append(
-                  f"- #{candidate.get('number')}: {candidate.get('title')} ({candidate.get('url')})"
+                  f"- #{candidate.get('number')}: {candidate.get('title')} ({candidate.get('url')}) — {candidate.get('similarity_reason', '')}"
               )
 
           summary_path.write_text(
@@ -130,8 +147,12 @@ jobs:
                       "",
                       f"- Repository: {result.get('repository')}",
                       f"- Issue: #{result.get('issue_number')}",
-                      f"- Duplicate: {result.get('is_duplicate')}",
+                      f"- Should comment: {result.get('should_comment')}",
+                      f"- Exact duplicate: {result.get('is_duplicate')}",
+                      f"- Auto-close candidate: {result.get('auto_close_candidate')}",
+                      f"- Classification: {result.get('classification')}",
                       f"- Confidence: {result.get('confidence')}",
+                      f"- Canonical issue: {canonical_issue_number}",
                       f"- Conversation: {result.get('conversation_url')}",
                       "",
                       "### Summary",
@@ -146,19 +167,68 @@ jobs:
           )
           PY
 
-      - name: Post duplicate notice comment
-        if: steps.parsed_result.outputs.is_duplicate == 'true' && steps.parsed_result.outputs.comment_body != ''
+      - name: Post duplicate overlap notice
+        if: steps.parsed_result.outputs.should_comment == 'true'
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
-          COMMENT_BODY: ${{ steps.parsed_result.outputs.comment_body }}
-          COMMENT_MARKER: '<!-- openhands-duplicate-check -->'
+          SUMMARY: ${{ steps.parsed_result.outputs.summary }}
+          CANDIDATE_ISSUES_JSON: ${{ steps.parsed_result.outputs.candidate_issues_json }}
+          CLASSIFICATION: ${{ steps.parsed_result.outputs.classification }}
+          AUTO_CLOSE_CANDIDATE: ${{ steps.parsed_result.outputs.auto_close_candidate }}
+          CANONICAL_ISSUE_NUMBER: ${{ steps.parsed_result.outputs.canonical_issue_number }}
         with:
           github-token: ${{ secrets.PLAYGROUND_GH_TOKEN }}
           script: |
             const issueNumber = Number(process.env.ISSUE_NUMBER);
-            const marker = process.env.COMMENT_MARKER;
-            const body = `${process.env.COMMENT_BODY}\n\n${marker}\n_This comment was created by an AI assistant (OpenHands) on behalf of the repository maintainer._`;
+            const summary = (process.env.SUMMARY || '').trim();
+            const classification = process.env.CLASSIFICATION || 'no-match';
+            const autoClose = process.env.AUTO_CLOSE_CANDIDATE === 'true';
+            const candidates = JSON.parse(process.env.CANDIDATE_ISSUES_JSON || '[]');
+            const canonicalIssueNumber = Number(process.env.CANONICAL_ISSUE_NUMBER || candidates?.[0]?.number || 0);
+
+            if (!Array.isArray(candidates) || candidates.length === 0) {
+              core.warning(`No candidate issues were returned for issue #${issueNumber}; skipping comment.`);
+              return;
+            }
+
+            const marker = `<!-- openhands-duplicate-check canonical=${canonicalIssueNumber} auto-close=${autoClose ? 'true' : 'false'} -->`;
+            const header = candidates.length === 1
+              ? 'Found 1 possible duplicate issue:'
+              : `Found ${candidates.length} possible duplicate issues:`;
+            const candidateLines = candidates.map((candidate, index) => (
+              `${index + 1}. [#${candidate.number}](${candidate.url}) — ${candidate.title}`
+            ));
+
+            const sections = [];
+            if (summary) {
+              sections.push(summary, '');
+            }
+            sections.push(header, '', ...candidateLines);
+
+            if (classification === 'overlapping-scope') {
+              sections.push(
+                '',
+                'These may not be exact duplicates, but the scope appears to overlap enough that keeping discussion in one place may be more useful.'
+              );
+            }
+
+            if (autoClose) {
+              sections.push(
+                '',
+                'This issue will be automatically closed as a duplicate in 3 days.',
+                '',
+                '- If your issue is a duplicate, please close it and 👍 the existing issue instead',
+                '- To prevent auto-closure, add a comment or 👎 this comment'
+              );
+            }
+
+            sections.push(
+              '',
+              marker,
+              '_This comment was created by an AI assistant (OpenHands) on behalf of the repository maintainer._'
+            );
+            const body = sections.join('\n').trim();
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -167,7 +237,7 @@ jobs:
               per_page: 100,
             });
 
-            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            const existing = comments.find((comment) => comment.body && comment.body.includes('<!-- openhands-duplicate-check '));
             if (existing) {
               core.info(`Duplicate check comment already exists on issue #${issueNumber}; skipping.`);
               return;
@@ -179,3 +249,36 @@ jobs:
               issue_number: issueNumber,
               body,
             });
+
+  auto-close-duplicates:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.mode == 'auto-close')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: remote-openhands-runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Auto-close aged duplicate candidates
+        env:
+          GITHUB_TOKEN: ${{ secrets.PLAYGROUND_GH_TOKEN }}
+          CLOSE_AFTER_DAYS: ${{ inputs.close_after_days || '3' }}
+        run: |
+          python scripts/auto_close_duplicate_issues.py \
+            --repository "${{ github.repository }}" \
+            --close-after-days "$CLOSE_AFTER_DAYS" | tee "$RUNNER_TEMP/auto-close-summary.json"
+
+      - name: Summarize auto-close run
+        run: |
+          {
+            echo "## Auto-close duplicate candidates"
+            echo
+            cat "$RUNNER_TEMP/auto-close-summary.json"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -243,11 +243,11 @@ jobs:
             }
 
             if (!Array.isArray(candidates) || candidates.length === 0) {
-              core.warning(`No candidate issues were returned for issue #${issueNumber}; skipping comment.`);
+              core.setFailed(`No candidate issues were returned for issue #${issueNumber}.`);
               return;
             }
             if (!Number.isInteger(canonicalIssueNumber) || canonicalIssueNumber <= 0) {
-              core.warning(`No canonical issue number was returned for issue #${issueNumber}; skipping comment.`);
+              core.setFailed(`No canonical issue number was returned for issue #${issueNumber}.`);
               return;
             }
 

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Validate duplicate check inputs
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
-          TARGET_REPOSITORY: ${{ github.event.repository.full_name || inputs.repository }}
+          TARGET_REPOSITORY: ${{ inputs.repository || github.event.repository.full_name }}
         run: |
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "Error: ISSUE_NUMBER is required"
@@ -100,7 +100,7 @@ jobs:
           OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.PLAYGROUND_GH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
-          TARGET_REPOSITORY: ${{ github.event.repository.full_name || inputs.repository }}
+          TARGET_REPOSITORY: ${{ inputs.repository || github.event.repository.full_name }}
           OUTPUT_PATH: ${{ runner.temp }}/issue-duplicate-check-result.json
         run: |
           python scripts/issue_duplicate_check_openhands.py \

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -1,0 +1,180 @@
+name: Issue Duplicate Check via OpenHands Cloud
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Which workflow path to run
+        required: true
+        type: choice
+        options:
+          - smoke-clone
+          - issue-check
+        default: smoke-clone
+      issue_number:
+        description: Existing issue number to analyze when mode is issue-check
+        required: false
+        type: number
+      repository:
+        description: Repository to inspect when mode is issue-check
+        required: false
+        type: string
+        default: enyst/playground
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  smoke-clone:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'smoke-clone'
+    runs-on: ubuntu-latest
+    environment: remote-openhands-runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Clone OpenHands and agent-sdk
+        run: |
+          git clone --depth 1 https://github.com/OpenHands/OpenHands.git /tmp/OpenHands
+          git clone --depth 1 https://github.com/OpenHands/agent-sdk.git /tmp/agent-sdk
+          echo "OpenHands HEAD: $(git -C /tmp/OpenHands rev-parse --short HEAD)"
+          echo "agent-sdk HEAD: $(git -C /tmp/agent-sdk rev-parse --short HEAD)"
+
+      - name: Summarize smoke test
+        run: |
+          {
+            echo "## Smoke clone completed"
+            echo
+            echo "- OpenHands cloned to /tmp/OpenHands"
+            echo "- agent-sdk cloned to /tmp/agent-sdk"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  issue-duplicate-check:
+    if: |
+      github.event_name == 'issues' ||
+      (github.event_name == 'workflow_dispatch' && inputs.mode == 'issue-check' && inputs.issue_number != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: remote-openhands-runner
+    concurrency:
+      group: issue-duplicate-check-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Run OpenHands duplicate check conversation
+        id: run_check
+        env:
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          TARGET_REPOSITORY: ${{ github.event.repository.full_name || inputs.repository }}
+          OUTPUT_PATH: ${{ runner.temp }}/issue-duplicate-check-result.json
+        run: |
+          python scripts/issue_duplicate_check_openhands.py \
+            --repository "$TARGET_REPOSITORY" \
+            --issue-number "$ISSUE_NUMBER" \
+            --output "$OUTPUT_PATH"
+          echo "result_path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Parse duplicate check result
+        id: parsed_result
+        env:
+          RESULT_PATH: ${{ steps.run_check.outputs.result_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(Path(os.environ['RESULT_PATH']).read_text())
+          output_path = Path(os.environ['GITHUB_OUTPUT'])
+          summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
+
+          def write_multiline(name: str, value: str) -> None:
+              with output_path.open('a', encoding='utf-8') as fh:
+                  fh.write(f"{name}<<EOF\n{value}\nEOF\n")
+
+          with output_path.open('a', encoding='utf-8') as fh:
+              fh.write(f"is_duplicate={'true' if result.get('is_duplicate') else 'false'}\n")
+              fh.write(f"confidence={result.get('confidence', '')}\n")
+              fh.write(f"conversation_url={result.get('conversation_url', '')}\n")
+              fh.write(f"app_conversation_id={result.get('app_conversation_id', '')}\n")
+
+          write_multiline('summary', str(result.get('summary', '')).strip())
+          write_multiline('comment_body', str(result.get('comment_body', '')).strip())
+          write_multiline(
+              'candidate_issues_json',
+              json.dumps(result.get('candidate_issues', []), ensure_ascii=False),
+          )
+
+          candidate_lines = []
+          for candidate in result.get('candidate_issues', []):
+              candidate_lines.append(
+                  f"- #{candidate.get('number')}: {candidate.get('title')} ({candidate.get('url')})"
+              )
+
+          summary_path.write_text(
+              "\n".join(
+                  [
+                      "## Duplicate check result",
+                      "",
+                      f"- Repository: {result.get('repository')}",
+                      f"- Issue: #{result.get('issue_number')}",
+                      f"- Duplicate: {result.get('is_duplicate')}",
+                      f"- Confidence: {result.get('confidence')}",
+                      f"- Conversation: {result.get('conversation_url')}",
+                      "",
+                      "### Summary",
+                      result.get('summary', ''),
+                      "",
+                      "### Candidate issues",
+                      *(candidate_lines or ["- None"]),
+                  ]
+              )
+              + "\n",
+              encoding='utf-8',
+          )
+          PY
+
+      - name: Post duplicate notice comment
+        if: steps.parsed_result.outputs.is_duplicate == 'true' && steps.parsed_result.outputs.comment_body != ''
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          COMMENT_BODY: ${{ steps.parsed_result.outputs.comment_body }}
+          COMMENT_MARKER: '<!-- openhands-duplicate-check -->'
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const marker = process.env.COMMENT_MARKER;
+            const body = `${process.env.COMMENT_BODY}\n\n${marker}\n_This comment was created by an AI assistant (OpenHands) on behalf of the repository maintainer._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              core.info(`Duplicate check comment already exists on issue #${issueNumber}; skipping.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -80,6 +80,20 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Validate duplicate check inputs
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          TARGET_REPOSITORY: ${{ github.event.repository.full_name || inputs.repository }}
+        run: |
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "Error: ISSUE_NUMBER is required"
+            exit 1
+          fi
+          if [ -z "$TARGET_REPOSITORY" ]; then
+            echo "Error: TARGET_REPOSITORY is required"
+            exit 1
+          fi
+
       - name: Run OpenHands duplicate check conversation
         id: run_check
         env:
@@ -177,6 +191,7 @@ jobs:
           CLASSIFICATION: ${{ steps.parsed_result.outputs.classification }}
           AUTO_CLOSE_CANDIDATE: ${{ steps.parsed_result.outputs.auto_close_candidate }}
           CANONICAL_ISSUE_NUMBER: ${{ steps.parsed_result.outputs.canonical_issue_number }}
+          CLOSE_AFTER_DAYS: ${{ inputs.close_after_days || '3' }}
         with:
           github-token: ${{ secrets.PLAYGROUND_GH_TOKEN }}
           script: |
@@ -184,6 +199,7 @@ jobs:
             const summary = (process.env.SUMMARY || '').trim();
             const classification = process.env.CLASSIFICATION || 'no-match';
             const autoClose = process.env.AUTO_CLOSE_CANDIDATE === 'true';
+            const closeAfterDays = process.env.CLOSE_AFTER_DAYS || '3';
             const candidates = JSON.parse(process.env.CANDIDATE_ISSUES_JSON || '[]');
             const canonicalIssueNumber = Number(process.env.CANONICAL_ISSUE_NUMBER || candidates?.[0]?.number || 0);
             const candidateLabel = 'duplicate-candidate';
@@ -230,6 +246,10 @@ jobs:
               core.warning(`No candidate issues were returned for issue #${issueNumber}; skipping comment.`);
               return;
             }
+            if (!Number.isInteger(canonicalIssueNumber) || canonicalIssueNumber <= 0) {
+              core.warning(`No canonical issue number was returned for issue #${issueNumber}; skipping comment.`);
+              return;
+            }
 
             const marker = `<!-- openhands-duplicate-check canonical=${canonicalIssueNumber} auto-close=${autoClose ? 'true' : 'false'} -->`;
             const header = candidates.length === 1
@@ -255,7 +275,7 @@ jobs:
             if (autoClose) {
               sections.push(
                 '',
-                'This issue will be automatically closed as a duplicate in 3 days.',
+                `This issue will be automatically closed as a duplicate in ${closeAfterDays} days.`,
                 '',
                 '- If your issue is a duplicate, please close it and 👍 the existing issue instead',
                 '- To prevent auto-closure, add a comment or 👎 this comment'

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -75,7 +75,7 @@ jobs:
         id: run_check
         env:
           OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.PLAYGROUND_GH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           TARGET_REPOSITORY: ${{ github.event.repository.full_name || inputs.repository }}
           OUTPUT_PATH: ${{ runner.temp }}/issue-duplicate-check-result.json
@@ -154,6 +154,7 @@ jobs:
           COMMENT_BODY: ${{ steps.parsed_result.outputs.comment_body }}
           COMMENT_MARKER: '<!-- openhands-duplicate-check -->'
         with:
+          github-token: ${{ secrets.PLAYGROUND_GH_TOKEN }}
           script: |
             const issueNumber = Number(process.env.ISSUE_NUMBER);
             const marker = process.env.COMMENT_MARKER;

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -186,6 +186,45 @@ jobs:
             const autoClose = process.env.AUTO_CLOSE_CANDIDATE === 'true';
             const candidates = JSON.parse(process.env.CANDIDATE_ISSUES_JSON || '[]');
             const canonicalIssueNumber = Number(process.env.CANONICAL_ISSUE_NUMBER || candidates?.[0]?.number || 0);
+            const candidateLabel = 'duplicate-candidate';
+
+            async function ensureCandidateLabelOnIssue() {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: candidateLabel,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: candidateLabel,
+                  color: 'C5DEF5',
+                  description: 'Potential duplicate awaiting auto-close or maintainer review',
+                });
+              }
+
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const labelNames = (issue.labels || []).map((label) => (
+                typeof label === 'string' ? label : label.name
+              ));
+              if (!labelNames.includes(candidateLabel)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: [candidateLabel],
+                });
+              }
+            }
 
             if (!Array.isArray(candidates) || candidates.length === 0) {
               core.warning(`No candidate issues were returned for issue #${issueNumber}; skipping comment.`);
@@ -239,6 +278,9 @@ jobs:
 
             const existing = comments.find((comment) => comment.body && comment.body.includes('<!-- openhands-duplicate-check '));
             if (existing) {
+              if (autoClose) {
+                await ensureCandidateLabelOnIssue();
+              }
               core.info(`Duplicate check comment already exists on issue #${issueNumber}; skipping.`);
               return;
             }
@@ -249,6 +291,10 @@ jobs:
               issue_number: issueNumber,
               body,
             });
+
+            if (autoClose) {
+              await ensureCandidateLabelOnIssue();
+            }
 
   auto-close-duplicates:
     if: |

--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -66,7 +66,7 @@ jobs:
       github.event_name == 'issues' ||
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'issue-check' && inputs.issue_number != '')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     environment: remote-openhands-runner
     concurrency:
       group: issue-duplicate-check-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -23,6 +23,7 @@ jobs:
             (
                 (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
                 github.event.action == 'ready_for_review' ||
+                github.event.action == 'synchronize' ||
                 (github.event.action == 'labeled' && github.event.label.name == 'review-this') ||
                 (
                     github.event.action == 'review_requested' &&

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -7,7 +7,7 @@ on:
     # We temporarily avoid `pull_request_target` here. We'll restore it after the PR review
     # workflow is fully hardened for untrusted execution.
     pull_request:
-        types: [opened, ready_for_review, labeled, review_requested]
+        types: [opened, ready_for_review, synchronize, labeled, review_requested]
 
 permissions:
     contents: read

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -23,7 +23,7 @@ jobs:
             (
                 (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
                 github.event.action == 'ready_for_review' ||
-                github.event.action == 'synchronize' ||
+                (github.event.action == 'synchronize' && github.event.pull_request.draft == false) ||
                 (github.event.action == 'labeled' && github.event.label.name == 'review-this') ||
                 (
                     github.event.action == 'review_requested' &&

--- a/.github/workflows/remove-duplicate-candidate-label.yml
+++ b/.github/workflows/remove-duplicate-candidate-label.yml
@@ -13,7 +13,9 @@ jobs:
       github.event.issue.state == 'open' &&
       github.event.issue.pull_request == null &&
       contains(github.event.issue.labels.*.name, 'duplicate-candidate') &&
-      github.event.comment.user.login != 'github-actions[bot]'
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      !contains(github.event.comment.body, '<!-- openhands-duplicate-check') &&
+      !contains(github.event.comment.body, '<!-- openhands-duplicate-veto')
     runs-on: ubuntu-latest
     environment: remote-openhands-runner
     steps:

--- a/.github/workflows/remove-duplicate-candidate-label.yml
+++ b/.github/workflows/remove-duplicate-candidate-label.yml
@@ -1,0 +1,47 @@
+name: Remove duplicate candidate label on activity
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  remove-duplicate-candidate:
+    if: |
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'duplicate-candidate') &&
+      github.event.comment.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    environment: remote-openhands-runner
+    steps:
+      - name: Remove duplicate-candidate label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PLAYGROUND_GH_TOKEN }}
+          script: |
+            const issueNumber = context.issue.number;
+            const commenter = context.payload.comment.user.login;
+
+            core.info(
+              `Removing duplicate-candidate label from issue #${issueNumber} after comment from ${commenter}`
+            );
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'duplicate-candidate',
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(
+                  `duplicate-candidate label was already removed from issue #${issueNumber}`
+                );
+                return;
+              }
+              throw error;
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,9 @@ When working on a PR that requires design documents, scripts meant for developme
 - Daily/manual auto-close runs also remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
 - Daily/manual auto-close runs remove that label instead of retrying auto-close when they detect newer comments after the duplicate notice.
 - The duplicate check poller tolerates empty OpenHands API payloads and retries instead of crashing.
+- The issue duplicate-check job uses a 35-minute workflow timeout because the script may spend up to two polling phases waiting on OpenHands.
+- Failed OpenHands conversation statuses (`error`, `errored`, `failed`, `stopped`) now fail fast instead of falling through to later parsing errors.
+- Duplicate result `classification` values are normalized case-insensitively before validation.
 - The duplicate notice marker format is `<!-- openhands-duplicate-check canonical=<issue> auto-close=<true|false> -->`.
 - The thumbs-down veto follow-up marker is `<!-- openhands-duplicate-veto -->`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,19 @@ When working on a PR that requires design documents, scripts meant for developme
 - Feature implementations that need temporary planning docs
 - Any analysis that helps reviewers understand the PR but isn't needed long-term
 
+## Issue Duplicate Automation (enyst/playground)
+
+- Workflow: `.github/workflows/issue-duplicate-checker.yml`
+- OpenHands duplicate-check runner script: `scripts/issue_duplicate_check_openhands.py`
+- Auto-close / veto polling script: `scripts/auto_close_duplicate_issues.py`
+- GitHub Actions environment: `remote-openhands-runner`
+- Required environment secrets: `PLAYGROUND_GH_TOKEN`, `OPENHANDS_API_KEY`
+- Auto-close candidates get the `duplicate-candidate` label when the duplicate notice is posted.
+- Daily/manual auto-close runs remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
+- The duplicate notice marker format is `<!-- openhands-duplicate-check canonical=<issue> auto-close=<true|false> -->`.
+- The thumbs-down veto follow-up marker is `<!-- openhands-duplicate-veto -->`.
+
+
 ## Repository Structure
 Backend:
 - Located in the `openhands` directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,10 @@ When working on a PR that requires design documents, scripts meant for developme
 - Required environment secrets: `PLAYGROUND_GH_TOKEN`, `OPENHANDS_API_KEY`
 - Auto-close candidates get the `duplicate-candidate` label when the duplicate notice is posted.
 - Daily/manual auto-close runs only scan open issues that currently have the `duplicate-candidate` label.
-- Daily/manual auto-close runs remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
+- Workflow: `.github/workflows/remove-duplicate-candidate-label.yml`
+- Non-bot issue comments immediately remove the `duplicate-candidate` label, matching the Claude Code `remove-autoclose-label.yml` pattern.
+- Daily/manual auto-close runs also remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
+- Daily/manual auto-close runs remove that label instead of retrying auto-close when they detect newer comments after the duplicate notice.
 - The duplicate check poller tolerates empty OpenHands API payloads and retries instead of crashing.
 - The duplicate notice marker format is `<!-- openhands-duplicate-check canonical=<issue> auto-close=<true|false> -->`.
 - The thumbs-down veto follow-up marker is `<!-- openhands-duplicate-veto -->`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ When working on a PR that requires design documents, scripts meant for developme
 - Daily/manual auto-close runs only scan open issues that currently have the `duplicate-candidate` label.
 - Workflow: `.github/workflows/remove-duplicate-candidate-label.yml`
 - Non-bot issue comments immediately remove the `duplicate-candidate` label, matching the Claude Code `remove-autoclose-label.yml` pattern.
+- The label-removal workflow ignores OpenHands duplicate/veto marker comments so it does not clear its own label immediately after automation posts.
 - Daily/manual auto-close runs also remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
 - Daily/manual auto-close runs remove that label instead of retrying auto-close when they detect newer comments after the duplicate notice.
 - The duplicate check poller tolerates empty OpenHands API payloads and retries instead of crashing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,9 @@ When working on a PR that requires design documents, scripts meant for developme
 - GitHub Actions environment: `remote-openhands-runner`
 - Required environment secrets: `PLAYGROUND_GH_TOKEN`, `OPENHANDS_API_KEY`
 - Auto-close candidates get the `duplicate-candidate` label when the duplicate notice is posted.
+- Daily/manual auto-close runs only scan open issues that currently have the `duplicate-candidate` label.
 - Daily/manual auto-close runs remove that label and leave a short follow-up note if the issue author reacts with 👎 to the duplicate notice comment.
+- The duplicate check poller tolerates empty OpenHands API payloads and retries instead of crashing.
 - The duplicate notice marker format is `<!-- openhands-duplicate-check canonical=<issue> auto-close=<true|false> -->`.
 - The thumbs-down veto follow-up marker is `<!-- openhands-duplicate-veto -->`.
 

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -93,6 +93,7 @@ def list_open_issues(repository: str) -> list[dict[str, Any]]:
                 continue
             issues.append(issue)
         page += 1
+    return issues
 
 
 def list_issue_comments(repository: str, issue_number: int) -> list[dict[str, Any]]:

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -224,7 +224,6 @@ def close_issue_as_duplicate(
     if dry_run:
         return
 
-    remove_candidate_label(repository, issue_number, dry_run=False)
     request_json(
         f'/repos/{repository}/issues/{issue_number}',
         method='PATCH',
@@ -241,6 +240,7 @@ def close_issue_as_duplicate(
             )
         },
     )
+    remove_candidate_label(repository, issue_number, dry_run=False)
 
 
 def main() -> int:

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -80,9 +81,10 @@ def parse_timestamp(value: str) -> datetime:
 def list_open_issues(repository: str) -> list[dict[str, Any]]:
     issues: list[dict[str, Any]] = []
     page = 1
+    label_query = urllib.parse.quote(DUPLICATE_CANDIDATE_LABEL)
     while True:
         payload = request_json(
-            f'/repos/{repository}/issues?state=open&per_page=100&page={page}'
+            f'/repos/{repository}/issues?state=open&labels={label_query}&per_page=100&page={page}'
         )
         if not isinstance(payload, list) or not payload:
             return issues
@@ -150,6 +152,25 @@ def issue_has_label(issue: dict[str, Any], label_name: str) -> bool:
         if isinstance(label, dict) and label.get('name') == label_name:
             return True
     return False
+
+
+def user_id_from_item(item: dict[str, Any]) -> int | None:
+    user = item.get('user')
+    if not isinstance(user, dict):
+        return None
+    user_id = user.get('id')
+    return user_id if isinstance(user_id, int) else None
+
+
+def has_reaction_from_user(
+    reactions: list[dict[str, Any]], user_id: int | None, content: str
+) -> bool:
+    if user_id is None:
+        return False
+    return any(
+        user_id_from_item(reaction) == user_id and reaction.get('content') == content
+        for reaction in reactions
+    )
 
 
 def has_veto_note(comments: list[dict[str, Any]]) -> bool:
@@ -244,18 +265,10 @@ def main() -> int:
         if comment_created_at > cutoff:
             continue
 
-        author_id = issue.get('user', {}).get('id')
+        author_id = user_id_from_item(issue)
         reactions = list_comment_reactions(args.repository, int(latest_comment['id']))
-        author_thumbs_down = any(
-            reaction.get('user', {}).get('id') == author_id
-            and reaction.get('content') == '-1'
-            for reaction in reactions
-        )
-        author_thumbs_up = any(
-            reaction.get('user', {}).get('id') == author_id
-            and reaction.get('content') == '+1'
-            for reaction in reactions
-        )
+        author_thumbs_down = has_reaction_from_user(reactions, author_id, '-1')
+        author_thumbs_up = has_reaction_from_user(reactions, author_id, '+1')
         if author_thumbs_down:
             label_removed = False
             if issue_has_label(issue, DUPLICATE_CANDIDATE_LABEL):

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -243,6 +243,28 @@ def close_issue_as_duplicate(
     remove_candidate_label(repository, issue_number, dry_run=False)
 
 
+def keep_open_due_to_newer_comments(
+    repository: str,
+    issue: dict[str, Any],
+    issue_number: int,
+    *,
+    dry_run: bool,
+) -> dict[str, Any]:
+    label_removed = False
+    if issue_has_label(issue, DUPLICATE_CANDIDATE_LABEL):
+        label_removed = remove_candidate_label(
+            repository,
+            issue_number,
+            dry_run=dry_run,
+        )
+    return {
+        'issue_number': issue_number,
+        'action': 'kept-open',
+        'reason': 'newer-comment-after-duplicate-notice',
+        'label_removed': label_removed,
+    }
+
+
 def main() -> int:
     args = parse_args()
     now = datetime.now(timezone.utc)
@@ -304,11 +326,12 @@ def main() -> int:
         ]
         if newer_comments:
             summary.append(
-                {
-                    'issue_number': issue_number,
-                    'action': 'kept-open',
-                    'reason': 'newer-comment-after-duplicate-notice',
-                }
+                keep_open_due_to_newer_comments(
+                    args.repository,
+                    issue,
+                    issue_number,
+                    dry_run=args.dry_run,
+                )
             )
             continue
 

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+GITHUB_API_BASE_URL = 'https://api.github.com'
+DUPLICATE_MARKER_RE = re.compile(
+    r'<!-- openhands-duplicate-check canonical=(?P<canonical>\d+) auto-close=(?P<auto_close>true|false) -->'
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Auto-close issues previously flagged as duplicate candidates.'
+    )
+    parser.add_argument('--repository', required=True)
+    parser.add_argument('--close-after-days', type=int, default=3)
+    parser.add_argument('--dry-run', action='store_true')
+    return parser.parse_args()
+
+
+def github_headers() -> dict[str, str]:
+    token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        raise RuntimeError('GITHUB_TOKEN environment variable is required')
+    return {
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'openhands-duplicate-auto-close',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+
+def request_json(
+    path: str,
+    *,
+    method: str = 'GET',
+    body: dict[str, Any] | None = None,
+) -> Any:
+    request_body = None
+    headers = github_headers()
+    if body is not None:
+        request_body = json.dumps(body).encode('utf-8')
+        headers['Content-Type'] = 'application/json'
+
+    request = urllib.request.Request(
+        f'{GITHUB_API_BASE_URL}{path}',
+        data=request_body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = response.read().decode('utf-8')
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode('utf-8', errors='replace')
+        raise RuntimeError(
+            f'{method} {path} failed with HTTP {exc.code}: {error_body}'
+        ) from exc
+
+    if not payload:
+        return None
+    return json.loads(payload)
+
+
+def parse_timestamp(value: str) -> datetime:
+    return datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+
+
+def list_open_issues(repository: str) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        payload = request_json(
+            f'/repos/{repository}/issues?state=open&per_page=100&page={page}'
+        )
+        if not isinstance(payload, list) or not payload:
+            return issues
+        for issue in payload:
+            if issue.get('pull_request'):
+                continue
+            issues.append(issue)
+        page += 1
+
+
+def list_issue_comments(repository: str, issue_number: int) -> list[dict[str, Any]]:
+    comments: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        payload = request_json(
+            f'/repos/{repository}/issues/{issue_number}/comments?per_page=100&page={page}'
+        )
+        if not isinstance(payload, list) or not payload:
+            return comments
+        comments.extend(payload)
+        page += 1
+
+
+def list_comment_reactions(repository: str, comment_id: int) -> list[dict[str, Any]]:
+    reactions: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        payload = request_json(
+            f'/repos/{repository}/issues/comments/{comment_id}/reactions?per_page=100&page={page}'
+        )
+        if not isinstance(payload, list) or not payload:
+            return reactions
+        reactions.extend(payload)
+        page += 1
+
+
+def extract_duplicate_metadata(comment_body: str) -> tuple[int | None, bool]:
+    match = DUPLICATE_MARKER_RE.search(comment_body)
+    if not match:
+        return None, False
+    return int(match.group('canonical')), match.group('auto_close') == 'true'
+
+
+def find_latest_auto_close_comment(
+    comments: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, int | None]:
+    latest_comment: dict[str, Any] | None = None
+    latest_canonical_issue: int | None = None
+    for comment in comments:
+        canonical_issue, auto_close = extract_duplicate_metadata(
+            comment.get('body') or ''
+        )
+        if canonical_issue is None or not auto_close:
+            continue
+        latest_comment = comment
+        latest_canonical_issue = canonical_issue
+    return latest_comment, latest_canonical_issue
+
+
+def close_issue_as_duplicate(
+    repository: str,
+    issue_number: int,
+    canonical_issue_number: int,
+    *,
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        return
+
+    request_json(
+        f'/repos/{repository}/issues/{issue_number}',
+        method='PATCH',
+        body={'state': 'closed', 'state_reason': 'duplicate'},
+    )
+    request_json(
+        f'/repos/{repository}/issues/{issue_number}/comments',
+        method='POST',
+        body={
+            'body': (
+                f'This issue has been automatically closed as a duplicate of #{canonical_issue_number}.\n\n'
+                'If this is incorrect, please add a comment and it can be reopened.\n\n'
+                '_This comment was created by an AI assistant (OpenHands) on behalf of the repository maintainer._'
+            )
+        },
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=args.close_after_days)
+
+    summary: list[dict[str, Any]] = []
+    for issue in list_open_issues(args.repository):
+        issue_number = int(issue['number'])
+        issue_created_at = parse_timestamp(issue['created_at'])
+        if issue_created_at > cutoff:
+            continue
+
+        comments = list_issue_comments(args.repository, issue_number)
+        latest_comment, canonical_issue_number = find_latest_auto_close_comment(
+            comments
+        )
+        if latest_comment is None or canonical_issue_number is None:
+            continue
+
+        comment_created_at = parse_timestamp(latest_comment['created_at'])
+        if comment_created_at > cutoff:
+            continue
+
+        newer_comments = [
+            comment
+            for comment in comments
+            if parse_timestamp(comment['created_at']) > comment_created_at
+        ]
+        if newer_comments:
+            summary.append(
+                {
+                    'issue_number': issue_number,
+                    'action': 'kept-open',
+                    'reason': 'newer-comment-after-duplicate-notice',
+                }
+            )
+            continue
+
+        author_id = issue.get('user', {}).get('id')
+        reactions = list_comment_reactions(args.repository, int(latest_comment['id']))
+        author_thumbs_down = any(
+            reaction.get('user', {}).get('id') == author_id
+            and reaction.get('content') == '-1'
+            for reaction in reactions
+        )
+        author_thumbs_up = any(
+            reaction.get('user', {}).get('id') == author_id
+            and reaction.get('content') == '+1'
+            for reaction in reactions
+        )
+        if author_thumbs_down:
+            summary.append(
+                {
+                    'issue_number': issue_number,
+                    'action': 'kept-open',
+                    'reason': 'author-thumbed-down-duplicate-comment',
+                    'author_thumbs_up': author_thumbs_up,
+                }
+            )
+            continue
+
+        close_issue_as_duplicate(
+            args.repository,
+            issue_number,
+            canonical_issue_number,
+            dry_run=args.dry_run,
+        )
+        summary.append(
+            {
+                'issue_number': issue_number,
+                'action': 'closed-as-duplicate'
+                if not args.dry_run
+                else 'would-close-as-duplicate',
+                'canonical_issue_number': canonical_issue_number,
+                'author_thumbs_up': author_thumbs_up,
+            }
+        )
+
+    print(json.dumps({'repository': args.repository, 'results': summary}, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001
+        print(f'error: {exc}', file=sys.stderr)
+        raise

--- a/scripts/auto_close_duplicate_issues.py
+++ b/scripts/auto_close_duplicate_issues.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 GITHUB_API_BASE_URL = 'https://api.github.com'
+DUPLICATE_CANDIDATE_LABEL = 'duplicate-candidate'
+DUPLICATE_VETO_MARKER = '<!-- openhands-duplicate-veto -->'
 DUPLICATE_MARKER_RE = re.compile(
     r'<!-- openhands-duplicate-check canonical=(?P<canonical>\d+) auto-close=(?P<auto_close>true|false) -->'
 )
@@ -140,6 +142,56 @@ def find_latest_auto_close_comment(
     return latest_comment, latest_canonical_issue
 
 
+def issue_has_label(issue: dict[str, Any], label_name: str) -> bool:
+    labels = issue.get('labels') or []
+    for label in labels:
+        if label == label_name:
+            return True
+        if isinstance(label, dict) and label.get('name') == label_name:
+            return True
+    return False
+
+
+def has_veto_note(comments: list[dict[str, Any]]) -> bool:
+    return any(
+        DUPLICATE_VETO_MARKER in (comment.get('body') or '') for comment in comments
+    )
+
+
+def remove_candidate_label(
+    repository: str, issue_number: int, *, dry_run: bool
+) -> bool:
+    if dry_run:
+        return True
+    try:
+        request_json(
+            f'/repos/{repository}/issues/{issue_number}/labels/{DUPLICATE_CANDIDATE_LABEL}',
+            method='DELETE',
+        )
+    except RuntimeError as exc:
+        if 'HTTP 404' in str(exc):
+            return False
+        raise
+    return True
+
+
+def post_veto_note(repository: str, issue_number: int, *, dry_run: bool) -> bool:
+    if dry_run:
+        return True
+    request_json(
+        f'/repos/{repository}/issues/{issue_number}/comments',
+        method='POST',
+        body={
+            'body': (
+                f'Thanks — leaving this open and removing the {DUPLICATE_CANDIDATE_LABEL} label.\n\n'
+                f'{DUPLICATE_VETO_MARKER}\n'
+                '_This comment was created by an AI assistant (OpenHands) on behalf of the repository maintainer._'
+            )
+        },
+    )
+    return True
+
+
 def close_issue_as_duplicate(
     repository: str,
     issue_number: int,
@@ -150,6 +202,7 @@ def close_issue_as_duplicate(
     if dry_run:
         return
 
+    remove_candidate_label(repository, issue_number, dry_run=False)
     request_json(
         f'/repos/{repository}/issues/{issue_number}',
         method='PATCH',
@@ -191,21 +244,6 @@ def main() -> int:
         if comment_created_at > cutoff:
             continue
 
-        newer_comments = [
-            comment
-            for comment in comments
-            if parse_timestamp(comment['created_at']) > comment_created_at
-        ]
-        if newer_comments:
-            summary.append(
-                {
-                    'issue_number': issue_number,
-                    'action': 'kept-open',
-                    'reason': 'newer-comment-after-duplicate-notice',
-                }
-            )
-            continue
-
         author_id = issue.get('user', {}).get('id')
         reactions = list_comment_reactions(args.repository, int(latest_comment['id']))
         author_thumbs_down = any(
@@ -219,12 +257,43 @@ def main() -> int:
             for reaction in reactions
         )
         if author_thumbs_down:
+            label_removed = False
+            if issue_has_label(issue, DUPLICATE_CANDIDATE_LABEL):
+                label_removed = remove_candidate_label(
+                    args.repository,
+                    issue_number,
+                    dry_run=args.dry_run,
+                )
+            veto_note_posted = False
+            if not has_veto_note(comments):
+                veto_note_posted = post_veto_note(
+                    args.repository,
+                    issue_number,
+                    dry_run=args.dry_run,
+                )
             summary.append(
                 {
                     'issue_number': issue_number,
                     'action': 'kept-open',
                     'reason': 'author-thumbed-down-duplicate-comment',
+                    'label_removed': label_removed,
+                    'veto_note_posted': veto_note_posted,
                     'author_thumbs_up': author_thumbs_up,
+                }
+            )
+            continue
+
+        newer_comments = [
+            comment
+            for comment in comments
+            if parse_timestamp(comment['created_at']) > comment_created_at
+        ]
+        if newer_comments:
+            summary.append(
+                {
+                    'issue_number': issue_number,
+                    'action': 'kept-open',
+                    'reason': 'newer-comment-after-duplicate-notice',
                 }
             )
             continue

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+OPENHANDS_BASE_URL = os.environ.get('OPENHANDS_BASE_URL', 'https://app.all-hands.dev')
+GITHUB_API_BASE_URL = os.environ.get('GITHUB_API_BASE_URL', 'https://api.github.com')
+TERMINAL_EXECUTION_STATUSES = {
+    'completed',
+    'error',
+    'errored',
+    'failed',
+    'finished',
+    'stopped',
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Start an OpenHands Cloud conversation that checks a GitHub issue for duplicates.'
+    )
+    parser.add_argument(
+        '--repository', required=True, help='Repository in owner/repo form'
+    )
+    parser.add_argument(
+        '--issue-number', required=True, type=int, help='Issue number to inspect'
+    )
+    parser.add_argument(
+        '--output',
+        default='duplicate-check-result.json',
+        help='Path where the JSON result should be written',
+    )
+    parser.add_argument(
+        '--poll-interval-seconds',
+        default=5,
+        type=int,
+        help='Polling interval while waiting for the conversation to finish',
+    )
+    parser.add_argument(
+        '--max-wait-seconds',
+        default=900,
+        type=int,
+        help='Maximum time to wait for the conversation to finish',
+    )
+    return parser.parse_args()
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'remote-openhands-runner-issue-duplicate-check',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+    github_token = os.environ.get('GITHUB_TOKEN')
+    if github_token:
+        headers['Authorization'] = f'Bearer {github_token}'
+    return headers
+
+
+def openhands_headers() -> dict[str, str]:
+    api_key = os.environ.get('OPENHANDS_API_KEY')
+    if not api_key:
+        raise RuntimeError('OPENHANDS_API_KEY is required')
+    return {
+        'Authorization': f'Bearer {api_key}',
+        'Content-Type': 'application/json',
+    }
+
+
+def request_json(
+    base_url: str,
+    path: str,
+    *,
+    method: str = 'GET',
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(body).encode('utf-8') if body is not None else None
+    request = urllib.request.Request(
+        f'{base_url}{path}',
+        data=data,
+        headers=headers or {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode('utf-8', errors='replace')
+        raise RuntimeError(
+            f'{method} {base_url}{path} failed with HTTP {exc.code}: {error_body}'
+        ) from exc
+
+
+def fetch_issue(repository: str, issue_number: int) -> dict[str, Any]:
+    return request_json(
+        GITHUB_API_BASE_URL,
+        f'/repos/{repository}/issues/{issue_number}',
+        headers=github_headers(),
+    )
+
+
+def escape_json_text(value: str | None) -> str:
+    return json.dumps(value or '', ensure_ascii=False)
+
+
+def build_prompt(repository: str, issue: dict[str, Any]) -> str:
+    issue_number = issue['number']
+    issue_title = issue.get('title', '')
+    issue_body = issue.get('body') or ''
+    issue_url = issue.get('html_url', '')
+
+    return f"""You are checking whether a GitHub issue is basically a duplicate of an existing issue.
+
+Repository: {repository}
+New issue number: #{issue_number}
+New issue URL: {issue_url}
+New issue title: {issue_title}
+New issue body (JSON-escaped string): {escape_json_text(issue_body)}
+
+Task:
+1. Understand the core bug report or request in the new issue.
+2. Search this repository's open issues and the issues that were closed in the last 30 days for likely duplicates or near-duplicates.
+3. Ignore pull requests when searching.
+4. Only mark the issue as a duplicate when the overlap is strong enough that a maintainer would probably redirect the author.
+5. Do not post comments, do not modify files, and do not change repository state.
+6. Use the public GitHub issue data for the repository. Useful API shapes include:
+   - GET https://api.github.com/repos/{repository}/issues?state=open&per_page=100
+   - GET https://api.github.com/repos/{repository}/issues?state=closed&since=<ISO-8601 timestamp>&per_page=100
+7. Return exactly one JSON object and nothing else. Do not wrap it in markdown fences.
+
+Return schema:
+{{
+  "issue_number": {issue_number},
+  "is_duplicate": true or false,
+  "confidence": "high" | "medium" | "low",
+  "summary": "short explanation",
+  "candidate_issues": [
+    {{
+      "number": 123,
+      "url": "https://github.com/{repository}/issues/123",
+      "title": "issue title",
+      "state": "open or closed",
+      "closed_at": "ISO timestamp or null",
+      "similarity_reason": "why it looks similar"
+    }}
+  ],
+  "comment_body": "concise issue comment to post if this is a duplicate, otherwise empty string"
+}}
+
+Rules for comment_body:
+- If is_duplicate is false, comment_body must be an empty string.
+- If is_duplicate is true, comment_body must be polite and concise, mention these are potential duplicates, and include markdown links to the candidate issues.
+- Keep comment_body to at most 4 sentences.
+"""
+
+
+def start_conversation(
+    prompt: str, repository: str, issue_number: int
+) -> dict[str, Any]:
+    body = {
+        'title': f'Issue duplicate check #{issue_number}',
+        'selected_repository': repository,
+        'initial_message': {
+            'content': [
+                {
+                    'type': 'text',
+                    'text': prompt,
+                }
+            ]
+        },
+    }
+    return request_json(
+        OPENHANDS_BASE_URL,
+        '/api/v1/app-conversations',
+        method='POST',
+        headers=openhands_headers(),
+        body=body,
+    )
+
+
+def poll_start_task(
+    start_task_id: str, poll_interval_seconds: int, max_wait_seconds: int
+) -> dict[str, Any]:
+    deadline = time.time() + max_wait_seconds
+    while time.time() < deadline:
+        payload = request_json(
+            OPENHANDS_BASE_URL,
+            f'/api/v1/app-conversations/start-tasks?ids={urllib.parse.quote(start_task_id)}',
+            headers={'Authorization': openhands_headers()['Authorization']},
+        )
+        item = (
+            payload[0]
+            if isinstance(payload, list) and payload
+            else payload.get('items', [{}])[0]
+        )
+        status = item.get('status')
+        if status == 'READY' and item.get('app_conversation_id'):
+            return item
+        if status in {'ERROR', 'FAILED'}:
+            raise RuntimeError(f'OpenHands start task failed: {json.dumps(item)}')
+        time.sleep(poll_interval_seconds)
+    raise TimeoutError(
+        f'Timed out waiting for start task {start_task_id} to become ready'
+    )
+
+
+def poll_conversation(
+    app_conversation_id: str, poll_interval_seconds: int, max_wait_seconds: int
+) -> dict[str, Any]:
+    deadline = time.time() + max_wait_seconds
+    while time.time() < deadline:
+        payload = request_json(
+            OPENHANDS_BASE_URL,
+            f'/api/v1/app-conversations?ids={urllib.parse.quote(app_conversation_id)}',
+            headers={'Authorization': openhands_headers()['Authorization']},
+        )
+        item = (
+            payload[0]
+            if isinstance(payload, list) and payload
+            else payload.get('items', [{}])[0]
+        )
+        execution_status = str(item.get('execution_status', '')).lower()
+        if execution_status in TERMINAL_EXECUTION_STATUSES:
+            return item
+        time.sleep(poll_interval_seconds)
+    raise TimeoutError(
+        f'Timed out waiting for conversation {app_conversation_id} to finish running'
+    )
+
+
+def fetch_app_server_events(app_conversation_id: str) -> list[dict[str, Any]]:
+    payload = request_json(
+        OPENHANDS_BASE_URL,
+        f'/api/v1/conversation/{urllib.parse.quote(app_conversation_id)}/events/search?limit=100',
+        headers={'Authorization': openhands_headers()['Authorization']},
+    )
+    if isinstance(payload, dict):
+        return payload.get('items', [])
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def fetch_agent_server_events(
+    app_conversation_id: str, agent_server_url: str, session_api_key: str
+) -> list[dict[str, Any]]:
+    payload = request_json(
+        agent_server_url,
+        f'/api/conversations/{urllib.parse.quote(app_conversation_id)}/events/search?limit=100',
+        headers={'X-Session-API-Key': session_api_key},
+    )
+    if isinstance(payload, dict):
+        return payload.get('items', [])
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def extract_last_agent_text(events: list[dict[str, Any]]) -> str:
+    messages: list[str] = []
+    for event in events:
+        if event.get('kind') != 'MessageEvent' or event.get('source') != 'agent':
+            continue
+        llm_message = event.get('llm_message') or {}
+        content = llm_message.get('content') or []
+        for part in content:
+            if part.get('type') == 'text' and part.get('text'):
+                messages.append(part['text'])
+    if not messages:
+        raise RuntimeError(
+            'No assistant text message was found in the conversation events'
+        )
+    return messages[-1].strip()
+
+
+def parse_agent_json(text: str) -> dict[str, Any]:
+    cleaned = text.strip()
+    if cleaned.startswith('```'):
+        cleaned = cleaned.split('\n', 1)[1]
+        cleaned = cleaned.rsplit('```', 1)[0].strip()
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        start = cleaned.find('{')
+        end = cleaned.rfind('}')
+        if start != -1 and end != -1 and end > start:
+            return json.loads(cleaned[start : end + 1])
+        raise
+
+
+def main() -> int:
+    args = parse_args()
+    issue = fetch_issue(args.repository, args.issue_number)
+    if issue.get('pull_request'):
+        raise RuntimeError(f'#{args.issue_number} is a pull request, not an issue')
+
+    prompt = build_prompt(args.repository, issue)
+    start_task = start_conversation(prompt, args.repository, args.issue_number)
+    app_conversation_id = start_task.get('app_conversation_id')
+    conversation_url = ''
+
+    if not app_conversation_id:
+        ready_task = poll_start_task(
+            start_task['id'],
+            args.poll_interval_seconds,
+            args.max_wait_seconds,
+        )
+        app_conversation_id = ready_task['app_conversation_id']
+
+    conversation = poll_conversation(
+        app_conversation_id,
+        args.poll_interval_seconds,
+        args.max_wait_seconds,
+    )
+    conversation_url = (
+        conversation.get('conversation_url')
+        or f'{OPENHANDS_BASE_URL}/conversations/{app_conversation_id}'
+    )
+    events = fetch_app_server_events(app_conversation_id)
+    try:
+        agent_text = extract_last_agent_text(events)
+    except RuntimeError:
+        session_api_key = conversation.get('session_api_key')
+        agent_server_url = ''
+        if conversation_url and '/api/conversations/' in conversation_url:
+            agent_server_url = conversation_url.rsplit('/api/conversations/', 1)[0]
+        if not agent_server_url or not session_api_key:
+            raise
+        events = fetch_agent_server_events(
+            app_conversation_id,
+            agent_server_url,
+            session_api_key,
+        )
+        agent_text = extract_last_agent_text(events)
+    result = parse_agent_json(agent_text)
+
+    result['issue_number'] = args.issue_number
+    result['repository'] = args.repository
+    result['app_conversation_id'] = app_conversation_id
+    result['conversation_url'] = conversation_url
+    result['agent_response'] = agent_text
+
+    output_path = Path(args.output)
+    output_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + '\n')
+
+    print(
+        json.dumps(
+            {
+                'issue_number': result.get('issue_number'),
+                'is_duplicate': result.get('is_duplicate'),
+                'confidence': result.get('confidence'),
+                'conversation_url': result.get('conversation_url'),
+                'output': str(output_path),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001
+        print(f'error: {exc}', file=sys.stderr)
+        raise

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -323,11 +323,20 @@ def parse_agent_json(text: str) -> dict[str, Any]:
     try:
         return json.loads(cleaned)
     except json.JSONDecodeError:
-        start = cleaned.find('{')
-        end = cleaned.rfind('}')
-        if start != -1 and end != -1 and end > start:
-            return json.loads(cleaned[start : end + 1])
-        raise
+        decoder = json.JSONDecoder()
+        for start, character in enumerate(cleaned):
+            if character != '{':
+                continue
+            try:
+                candidate, end = decoder.raw_decode(cleaned[start:])
+            except json.JSONDecodeError:
+                continue
+            trailing = cleaned[start + end :].strip()
+            if trailing not in {'', '```'}:
+                continue
+            if isinstance(candidate, dict):
+                return candidate
+        raise ValueError('No valid JSON object found in the agent response')
 
 
 def as_bool(value: Any) -> bool:

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -14,14 +14,19 @@ from typing import Any
 
 OPENHANDS_BASE_URL = os.environ.get('OPENHANDS_BASE_URL', 'https://app.all-hands.dev')
 GITHUB_API_BASE_URL = os.environ.get('GITHUB_API_BASE_URL', 'https://api.github.com')
-TERMINAL_EXECUTION_STATUSES = {
-    'completed',
+FAILED_EXECUTION_STATUSES = {
     'error',
     'errored',
     'failed',
-    'finished',
     'stopped',
 }
+SUCCESSFUL_TERMINAL_EXECUTION_STATUSES = {
+    'completed',
+    'finished',
+}
+TERMINAL_EXECUTION_STATUSES = (
+    FAILED_EXECUTION_STATUSES | SUCCESSFUL_TERMINAL_EXECUTION_STATUSES
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -268,7 +273,11 @@ def poll_conversation(
             time.sleep(poll_interval_seconds)
             continue
         execution_status = str(item.get('execution_status', '')).lower()
-        if execution_status in TERMINAL_EXECUTION_STATUSES:
+        if execution_status in FAILED_EXECUTION_STATUSES:
+            raise RuntimeError(
+                f'OpenHands conversation ended with {execution_status}: {json.dumps(item)}'
+            )
+        if execution_status in SUCCESSFUL_TERMINAL_EXECUTION_STATUSES:
             return item
         time.sleep(poll_interval_seconds)
     raise TimeoutError(
@@ -358,7 +367,7 @@ def normalize_result(result: dict[str, Any]) -> dict[str, Any]:
     normalized['is_duplicate'] = as_bool(normalized.get('is_duplicate'))
     normalized['auto_close_candidate'] = as_bool(normalized.get('auto_close_candidate'))
 
-    classification = str(normalized.get('classification') or 'no-match').strip()
+    classification = str(normalized.get('classification') or 'no-match').strip().lower()
     if classification not in {
         'duplicate',
         'overlapping-scope',

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -119,7 +119,11 @@ def build_prompt(repository: str, issue: dict[str, Any]) -> str:
     issue_body = issue.get('body') or ''
     issue_url = issue.get('html_url', '')
 
-    return f"""You are checking whether a GitHub issue is basically a duplicate of an existing issue.
+    return f"""You are investigating whether a GitHub issue should be redirected to an existing issue because it is either:
+- an exact or near-exact duplicate, or
+- so overlapping in scope that discussion or fix planning would likely be better kept in one canonical issue.
+
+Be conservative about auto-close decisions, but do investigate seriously before deciding.
 
 Repository: {repository}
 New issue number: #{issue_number}
@@ -128,22 +132,34 @@ New issue title: {issue_title}
 New issue body (JSON-escaped string): {escape_json_text(issue_body)}
 
 Task:
-1. Understand the core bug report or request in the new issue.
-2. Search this repository's open issues and the issues that were closed in the last 30 days for likely duplicates or near-duplicates.
-3. Ignore pull requests when searching.
-4. Only mark the issue as a duplicate when the overlap is strong enough that a maintainer would probably redirect the author.
-5. Do not post comments, do not modify files, and do not change repository state.
-6. Use the public GitHub issue data for the repository. Useful API shapes include:
+1. Understand the core problem, user-facing outcome, likely root cause, and requested fix or behavior.
+2. Investigate this repository's open issues and issues closed in the last 90 days for exact duplicates, near-duplicates, or strong scope overlap.
+3. Use multiple search approaches with diverse keywords and phrasings rather than a single literal search.
+4. Ignore pull requests.
+5. Distinguish carefully between:
+   - duplicate: essentially the same report, request, or root cause
+   - overlapping-scope: not identical, but likely to fragment discussion or produce competing fixes
+   - related-but-distinct: similar area, but should stay separate
+   - no-match: no strong candidate worth redirecting to
+6. Inspect the strongest 1-3 candidates carefully. If needed, inspect comments on the strongest candidates to disambiguate false positives.
+7. Do not post comments, do not modify files, and do not change repository state.
+8. Useful API shapes include:
    - GET https://api.github.com/repos/{repository}/issues?state=open&per_page=100
    - GET https://api.github.com/repos/{repository}/issues?state=closed&since=<ISO-8601 timestamp>&per_page=100
-7. Return exactly one JSON object and nothing else. Do not wrap it in markdown fences.
+   - GET https://api.github.com/search/issues?q=<query>
+   - GET https://api.github.com/repos/{repository}/issues/<number>/comments
+9. Return exactly one JSON object and nothing else. Do not wrap it in markdown fences.
 
 Return schema:
 {{
   "issue_number": {issue_number},
+  "should_comment": true or false,
   "is_duplicate": true or false,
+  "auto_close_candidate": true or false,
+  "classification": "duplicate" | "overlapping-scope" | "related-but-distinct" | "no-match",
   "confidence": "high" | "medium" | "low",
   "summary": "short explanation",
+  "canonical_issue_number": 123 or null,
   "candidate_issues": [
     {{
       "number": 123,
@@ -153,14 +169,21 @@ Return schema:
       "closed_at": "ISO timestamp or null",
       "similarity_reason": "why it looks similar"
     }}
-  ],
-  "comment_body": "concise issue comment to post if this is a duplicate, otherwise empty string"
+  ]
 }}
 
-Rules for comment_body:
-- If is_duplicate is false, comment_body must be an empty string.
-- If is_duplicate is true, comment_body must be polite and concise, mention these are potential duplicates, and include markdown links to the candidate issues.
-- Keep comment_body to at most 4 sentences.
+Rules:
+- `should_comment` should be true only when redirecting the author would likely help.
+- `is_duplicate` should be true only for exact or near-exact duplicates.
+- `auto_close_candidate` should be true only when:
+  - classification is `duplicate`
+  - confidence is `high`
+  - one canonical issue clearly stands out
+  - a maintainer would likely be comfortable closing this issue after a waiting period
+- For `overlapping-scope`, `auto_close_candidate` must be false.
+- `candidate_issues` must contain at most 3 issues, sorted best-first.
+- If no strong match exists, return `should_comment: false`, `classification: "no-match"`, `canonical_issue_number: null`, and an empty candidate list.
+- Be especially careful not to collapse broad meta, tracking, feedback, or umbrella issues with specific bug reports unless the new issue clearly belongs in that exact thread.
 """
 
 
@@ -298,6 +321,81 @@ def parse_agent_json(text: str) -> dict[str, Any]:
         raise
 
 
+def as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {'true', '1', 'yes'}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def normalize_result(result: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(result)
+    normalized['should_comment'] = as_bool(normalized.get('should_comment'))
+    normalized['is_duplicate'] = as_bool(normalized.get('is_duplicate'))
+    normalized['auto_close_candidate'] = as_bool(normalized.get('auto_close_candidate'))
+
+    classification = str(normalized.get('classification') or 'no-match').strip()
+    if classification not in {
+        'duplicate',
+        'overlapping-scope',
+        'related-but-distinct',
+        'no-match',
+    }:
+        classification = 'no-match'
+    normalized['classification'] = classification
+
+    confidence = str(normalized.get('confidence') or 'low').strip().lower()
+    if confidence not in {'high', 'medium', 'low'}:
+        confidence = 'low'
+    normalized['confidence'] = confidence
+
+    try:
+        canonical_issue_number = normalized.get('canonical_issue_number')
+        normalized['canonical_issue_number'] = (
+            int(canonical_issue_number)
+            if canonical_issue_number not in {None, ''}
+            else None
+        )
+    except (TypeError, ValueError):
+        normalized['canonical_issue_number'] = None
+
+    candidate_issues = normalized.get('candidate_issues')
+    if not isinstance(candidate_issues, list):
+        candidate_issues = []
+    normalized['candidate_issues'] = candidate_issues[:3]
+
+    if classification not in {'duplicate', 'overlapping-scope'}:
+        normalized['should_comment'] = False
+    if classification != 'duplicate':
+        normalized['is_duplicate'] = False
+        normalized['auto_close_candidate'] = False
+    if (
+        classification in {'duplicate', 'overlapping-scope'}
+        and normalized['candidate_issues']
+        and confidence in {'high', 'medium'}
+    ):
+        normalized['should_comment'] = True
+    if normalized['auto_close_candidate'] and confidence != 'high':
+        normalized['auto_close_candidate'] = False
+    if (
+        normalized['auto_close_candidate']
+        and normalized['canonical_issue_number'] is None
+    ):
+        first_candidate = (
+            normalized['candidate_issues'][0] if normalized['candidate_issues'] else {}
+        )
+        try:
+            normalized['canonical_issue_number'] = int(first_candidate.get('number'))
+        except (TypeError, ValueError, AttributeError):
+            normalized['auto_close_candidate'] = False
+
+    normalized['summary'] = str(normalized.get('summary') or '').strip()
+    return normalized
+
+
 def main() -> int:
     args = parse_args()
     issue = fetch_issue(args.repository, args.issue_number)
@@ -342,7 +440,7 @@ def main() -> int:
             session_api_key,
         )
         agent_text = extract_last_agent_text(events)
-    result = parse_agent_json(agent_text)
+    result = normalize_result(parse_agent_json(agent_text))
 
     result['issue_number'] = args.issue_number
     result['repository'] = args.repository
@@ -357,7 +455,10 @@ def main() -> int:
         json.dumps(
             {
                 'issue_number': result.get('issue_number'),
+                'should_comment': result.get('should_comment'),
                 'is_duplicate': result.get('is_duplicate'),
+                'auto_close_candidate': result.get('auto_close_candidate'),
+                'classification': result.get('classification'),
                 'confidence': result.get('confidence'),
                 'conversation_url': result.get('conversation_url'),
                 'output': str(output_path),

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -49,7 +49,10 @@ def parse_args() -> argparse.Namespace:
         '--max-wait-seconds',
         default=900,
         type=int,
-        help='Maximum time to wait for the conversation to finish',
+        help=(
+            'Maximum time to wait per polling phase; if a start task must be awaited '
+            'first, the total runtime can approach twice this value'
+        ),
     )
     return parser.parse_args()
 
@@ -447,11 +450,17 @@ def main() -> int:
         agent_text = extract_last_agent_text(events)
     except RuntimeError:
         session_api_key = conversation.get('session_api_key')
-        agent_server_url = ''
-        if conversation_url and '/api/conversations/' in conversation_url:
-            agent_server_url = conversation_url.rsplit('/api/conversations/', 1)[0]
-        if not agent_server_url or not session_api_key:
-            raise
+        if not session_api_key:
+            raise RuntimeError(
+                'session_api_key was missing from the OpenHands conversation'
+            )
+
+        marker = '/api/conversations/'
+        if marker not in conversation_url:
+            raise RuntimeError(
+                f'Cannot extract agent server URL from conversation URL: {conversation_url}'
+            )
+        agent_server_url = conversation_url.rsplit(marker, 1)[0]
         events = fetch_agent_server_events(
             app_conversation_id,
             agent_server_url,

--- a/scripts/issue_duplicate_check_openhands.py
+++ b/scripts/issue_duplicate_check_openhands.py
@@ -211,6 +211,20 @@ def start_conversation(
     )
 
 
+def extract_first_item(payload: Any) -> dict[str, Any] | None:
+    if isinstance(payload, list):
+        first_item = payload[0] if payload else None
+        return first_item if isinstance(first_item, dict) else None
+    if not isinstance(payload, dict):
+        return None
+
+    items = payload.get('items')
+    if isinstance(items, list):
+        first_item = items[0] if items else None
+        return first_item if isinstance(first_item, dict) else None
+    return payload
+
+
 def poll_start_task(
     start_task_id: str, poll_interval_seconds: int, max_wait_seconds: int
 ) -> dict[str, Any]:
@@ -221,11 +235,10 @@ def poll_start_task(
             f'/api/v1/app-conversations/start-tasks?ids={urllib.parse.quote(start_task_id)}',
             headers={'Authorization': openhands_headers()['Authorization']},
         )
-        item = (
-            payload[0]
-            if isinstance(payload, list) and payload
-            else payload.get('items', [{}])[0]
-        )
+        item = extract_first_item(payload)
+        if item is None:
+            time.sleep(poll_interval_seconds)
+            continue
         status = item.get('status')
         if status == 'READY' and item.get('app_conversation_id'):
             return item
@@ -247,11 +260,10 @@ def poll_conversation(
             f'/api/v1/app-conversations?ids={urllib.parse.quote(app_conversation_id)}',
             headers={'Authorization': openhands_headers()['Authorization']},
         )
-        item = (
-            payload[0]
-            if isinstance(payload, list) and payload
-            else payload.get('items', [{}])[0]
-        )
+        item = extract_first_item(payload)
+        if item is None:
+            time.sleep(poll_interval_seconds)
+            continue
         execution_status = str(item.get('execution_status', '')).lower()
         if execution_status in TERMINAL_EXECUTION_STATUSES:
             return item
@@ -308,9 +320,6 @@ def extract_last_agent_text(events: list[dict[str, Any]]) -> str:
 
 def parse_agent_json(text: str) -> dict[str, Any]:
     cleaned = text.strip()
-    if cleaned.startswith('```'):
-        cleaned = cleaned.split('\n', 1)[1]
-        cleaned = cleaned.rsplit('```', 1)[0].strip()
     try:
         return json.loads(cleaned)
     except json.JSONDecodeError:

--- a/tests/unit/test_issue_duplicate_scripts.py
+++ b/tests/unit/test_issue_duplicate_scripts.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import itertools
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_COUNTER = itertools.count()
+
+
+def load_module(script_name: str):
+    path = ROOT / 'scripts' / script_name
+    module_name = f'test_{path.stem}_{next(MODULE_COUNTER)}'
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f'Unable to load module from {path}')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_list_open_issues_filters_by_duplicate_candidate_label(monkeypatch):
+    module = load_module('auto_close_duplicate_issues.py')
+    requested_paths: list[str] = []
+
+    def fake_request_json(path: str, *, method: str = 'GET', body=None):
+        requested_paths.append(path)
+        return []
+
+    monkeypatch.setattr(module, 'request_json', fake_request_json)
+
+    assert module.list_open_issues('enyst/playground') == []
+    assert requested_paths == [
+        '/repos/enyst/playground/issues?state=open&labels=duplicate-candidate&per_page=100&page=1'
+    ]
+
+
+def test_has_reaction_from_user_ignores_missing_user_ids():
+    module = load_module('auto_close_duplicate_issues.py')
+    reactions = [
+        {'user': None, 'content': '-1'},
+        {'user': {'id': 42}, 'content': '-1'},
+    ]
+
+    assert module.user_id_from_item({'user': None}) is None
+    assert module.has_reaction_from_user(reactions, None, '-1') is False
+    assert module.has_reaction_from_user(reactions, 42, '-1') is True
+    assert module.has_reaction_from_user(reactions, 42, '+1') is False
+
+
+def test_parse_agent_json_handles_single_line_fenced_json():
+    module = load_module('issue_duplicate_check_openhands.py')
+
+    assert module.parse_agent_json('```json{"key":"value"}```') == {'key': 'value'}
+
+
+def test_poll_start_task_retries_after_empty_payload(monkeypatch):
+    module = load_module('issue_duplicate_check_openhands.py')
+    responses = [
+        [],
+        {'items': [{'status': 'READY', 'app_conversation_id': 'conv-123'}]},
+    ]
+
+    monkeypatch.setattr(
+        module, 'request_json', lambda *args, **kwargs: responses.pop(0)
+    )
+    monkeypatch.setattr(
+        module, 'openhands_headers', lambda: {'Authorization': 'Bearer test-token'}
+    )
+    monkeypatch.setattr(module.time, 'time', lambda: 0)
+    monkeypatch.setattr(module.time, 'sleep', lambda _seconds: None)
+
+    item = module.poll_start_task(
+        'task-123', poll_interval_seconds=1, max_wait_seconds=10
+    )
+
+    assert item['app_conversation_id'] == 'conv-123'
+
+
+def test_poll_conversation_retries_after_empty_items(monkeypatch):
+    module = load_module('issue_duplicate_check_openhands.py')
+    responses = [
+        {'items': []},
+        {
+            'items': [
+                {
+                    'execution_status': 'completed',
+                    'conversation_url': 'https://example.test',
+                }
+            ]
+        },
+    ]
+
+    monkeypatch.setattr(
+        module, 'request_json', lambda *args, **kwargs: responses.pop(0)
+    )
+    monkeypatch.setattr(
+        module, 'openhands_headers', lambda: {'Authorization': 'Bearer test-token'}
+    )
+    monkeypatch.setattr(module.time, 'time', lambda: 0)
+    monkeypatch.setattr(module.time, 'sleep', lambda _seconds: None)
+
+    item = module.poll_conversation(
+        'conv-123', poll_interval_seconds=1, max_wait_seconds=10
+    )
+
+    assert item['execution_status'] == 'completed'

--- a/tests/unit/test_issue_duplicate_scripts.py
+++ b/tests/unit/test_issue_duplicate_scripts.py
@@ -48,10 +48,61 @@ def test_has_reaction_from_user_ignores_missing_user_ids():
     assert module.has_reaction_from_user(reactions, 42, '+1') is False
 
 
+def test_find_latest_auto_close_comment_returns_latest_candidate():
+    module = load_module('auto_close_duplicate_issues.py')
+    comments = [
+        {'body': 'plain comment'},
+        {
+            'body': '<!-- openhands-duplicate-check canonical=10 auto-close=false -->',
+            'id': 1,
+        },
+        {
+            'body': '<!-- openhands-duplicate-check canonical=11 auto-close=true -->',
+            'id': 2,
+        },
+        {
+            'body': '<!-- openhands-duplicate-check canonical=12 auto-close=true -->',
+            'id': 3,
+        },
+    ]
+
+    latest_comment, canonical_issue = module.find_latest_auto_close_comment(comments)
+
+    assert latest_comment == comments[-1]
+    assert canonical_issue == 12
+
+
 def test_parse_agent_json_handles_single_line_fenced_json():
     module = load_module('issue_duplicate_check_openhands.py')
 
     assert module.parse_agent_json('```json{"key":"value"}```') == {'key': 'value'}
+
+
+def test_normalize_result_promotes_actionable_duplicates():
+    module = load_module('issue_duplicate_check_openhands.py')
+    normalized = module.normalize_result(
+        {
+            'classification': 'duplicate',
+            'confidence': 'HIGH',
+            'should_comment': False,
+            'is_duplicate': True,
+            'auto_close_candidate': '1',
+            'canonical_issue_number': '',
+            'candidate_issues': [
+                {'number': '21', 'title': 'First'},
+                {'number': 22, 'title': 'Second'},
+                {'number': 23, 'title': 'Third'},
+                {'number': 24, 'title': 'Fourth'},
+            ],
+            'summary': '  duplicate summary  ',
+        }
+    )
+
+    assert normalized['should_comment'] is True
+    assert normalized['auto_close_candidate'] is True
+    assert normalized['canonical_issue_number'] == 21
+    assert len(normalized['candidate_issues']) == 3
+    assert normalized['summary'] == 'duplicate summary'
 
 
 def test_poll_start_task_retries_after_empty_payload(monkeypatch):

--- a/tests/unit/test_issue_duplicate_scripts.py
+++ b/tests/unit/test_issue_duplicate_scripts.py
@@ -111,6 +111,34 @@ def test_close_issue_as_duplicate_leaves_label_until_requests_succeed(monkeypatc
     ]
 
 
+def test_keep_open_due_to_newer_comments_removes_candidate_label(monkeypatch):
+    module = load_module('auto_close_duplicate_issues.py')
+    calls: list[tuple[str, int, bool]] = []
+
+    def fake_remove_candidate_label(
+        repository: str, issue_number: int, *, dry_run: bool
+    ):
+        calls.append((repository, issue_number, dry_run))
+        return True
+
+    monkeypatch.setattr(module, 'remove_candidate_label', fake_remove_candidate_label)
+
+    result = module.keep_open_due_to_newer_comments(
+        'enyst/playground',
+        {'labels': [{'name': 'duplicate-candidate'}]},
+        123,
+        dry_run=False,
+    )
+
+    assert result == {
+        'issue_number': 123,
+        'action': 'kept-open',
+        'reason': 'newer-comment-after-duplicate-notice',
+        'label_removed': True,
+    }
+    assert calls == [('enyst/playground', 123, False)]
+
+
 def test_parse_agent_json_handles_single_line_fenced_json():
     module = load_module('issue_duplicate_check_openhands.py')
 

--- a/tests/unit/test_issue_duplicate_scripts.py
+++ b/tests/unit/test_issue_duplicate_scripts.py
@@ -172,6 +172,26 @@ def test_normalize_result_promotes_actionable_duplicates():
     assert normalized['summary'] == 'duplicate summary'
 
 
+def test_normalize_result_lowercases_classification():
+    module = load_module('issue_duplicate_check_openhands.py')
+    normalized = module.normalize_result(
+        {
+            'classification': 'Duplicate',
+            'confidence': 'HIGH',
+            'should_comment': True,
+            'is_duplicate': True,
+            'auto_close_candidate': True,
+            'canonical_issue_number': 21,
+            'candidate_issues': [{'number': 21, 'title': 'Existing issue'}],
+        }
+    )
+
+    assert normalized['classification'] == 'duplicate'
+    assert normalized['should_comment'] is True
+    assert normalized['is_duplicate'] is True
+    assert normalized['auto_close_candidate'] is True
+
+
 def test_poll_start_task_retries_after_empty_payload(monkeypatch):
     module = load_module('issue_duplicate_check_openhands.py')
     responses = [
@@ -223,3 +243,36 @@ def test_poll_conversation_retries_after_empty_items(monkeypatch):
     )
 
     assert item['execution_status'] == 'completed'
+
+
+def test_poll_conversation_raises_on_failed_status(monkeypatch):
+    module = load_module('issue_duplicate_check_openhands.py')
+
+    monkeypatch.setattr(
+        module,
+        'request_json',
+        lambda *args, **kwargs: {
+            'items': [
+                {
+                    'execution_status': 'failed',
+                    'conversation_url': 'https://example.test',
+                    'error_detail': 'boom',
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        module, 'openhands_headers', lambda: {'Authorization': 'Bearer test-token'}
+    )
+    monkeypatch.setattr(module.time, 'time', lambda: 0)
+    monkeypatch.setattr(module.time, 'sleep', lambda _seconds: None)
+
+    try:
+        module.poll_conversation(
+            'conv-123', poll_interval_seconds=1, max_wait_seconds=10
+        )
+    except RuntimeError as exc:
+        assert 'OpenHands conversation ended with failed' in str(exc)
+        assert 'boom' in str(exc)
+    else:
+        raise AssertionError('Expected poll_conversation to raise on failed status')

--- a/tests/unit/test_issue_duplicate_scripts.py
+++ b/tests/unit/test_issue_duplicate_scripts.py
@@ -72,6 +72,45 @@ def test_find_latest_auto_close_comment_returns_latest_candidate():
     assert canonical_issue == 12
 
 
+def test_close_issue_as_duplicate_leaves_label_until_requests_succeed(monkeypatch):
+    module = load_module('auto_close_duplicate_issues.py')
+    calls: list[tuple[str, str]] = []
+
+    def fake_request_json(path: str, *, method: str = 'GET', body=None):
+        calls.append((method, path))
+        if method == 'POST' and path.endswith('/comments'):
+            raise RuntimeError('comment failed')
+        return {}
+
+    def fake_remove_candidate_label(
+        repository: str, issue_number: int, *, dry_run: bool
+    ):
+        calls.append(('REMOVE_LABEL', f'{repository}#{issue_number}:{dry_run}'))
+        return True
+
+    monkeypatch.setattr(module, 'request_json', fake_request_json)
+    monkeypatch.setattr(module, 'remove_candidate_label', fake_remove_candidate_label)
+
+    try:
+        module.close_issue_as_duplicate(
+            'enyst/playground',
+            123,
+            45,
+            dry_run=False,
+        )
+    except RuntimeError as exc:
+        assert str(exc) == 'comment failed'
+    else:
+        raise AssertionError(
+            'Expected close_issue_as_duplicate to propagate the failure'
+        )
+
+    assert calls == [
+        ('PATCH', '/repos/enyst/playground/issues/123'),
+        ('POST', '/repos/enyst/playground/issues/123/comments'),
+    ]
+
+
 def test_parse_agent_json_handles_single_line_fenced_json():
     module = load_module('issue_duplicate_check_openhands.py')
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

We want to test an OpenHands-powered GitHub issue duplicate workflow in `enyst/playground` using the normal PR review process, so AI reviewers can comment on the exact automation diff before we consider broader use.

## Summary

- add a GitHub Actions workflow that sends new issues to OpenHands Cloud for duplicate / overlap analysis
- add follow-up automation for duplicate-candidate labeling, timed auto-close, and thumbs-down veto handling
- harden the automation scripts and PR review workflow based on bot review feedback

## Issue Number

N/A

## How to Test

1. Confirm the `remote-openhands-runner` environment contains `PLAYGROUND_GH_TOKEN` and `OPENHANDS_API_KEY`.
2. Open a new issue in `enyst/playground` that is very similar to an existing one.
3. Wait for `.github/workflows/issue-duplicate-checker.yml` to run on the `issues` event.
4. Verify the workflow posts a duplicate notice, including the 3-day auto-close guidance.
5. If the issue is an auto-close candidate, verify the `duplicate-candidate` label is applied.
6. React with 👎 as the issue author on the duplicate notice comment.
7. Run the workflow manually in `auto-close` mode or wait for the scheduled run.
8. Verify the issue stays open, the `duplicate-candidate` label is removed, and the short veto follow-up note is posted.
9. Push a small follow-up commit to the PR and verify `.github/workflows/pr-review-by-openhands.yml` reruns on `pull_request.synchronize` using `github.token` fallback when `ALLHANDS_BOT_GITHUB_PAT` is absent.

## Evidence

- Duplicate notice test issue: https://github.com/enyst/playground/issues/122
- Duplicate notice comment on `#122`: https://github.com/enyst/playground/issues/122#issuecomment-4256547560
- Veto follow-up comment on `#122`: https://github.com/enyst/playground/issues/122#issuecomment-4256555644
- Auto-close workflow run that honored the thumbs-down veto: https://github.com/enyst/playground/actions/runs/24485409882
- Current PR branch adds regression coverage in `tests/unit/test_issue_duplicate_scripts.py` for:
  - label-filtered issue scanning
  - deleted-user-safe reaction handling
  - empty OpenHands polling payload retries
  - fenced JSON parsing

## Video/Screenshots

None.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR description was created by an AI assistant (OpenHands) on behalf of the user.
- `main` was temporarily force-reset so this PR shows the exact automation diff for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated issue duplicate detection and management via OpenHands Cloud, including manual, scheduled, and auto-close modes
  * Auto-close flow that closes labeled duplicate candidates after author confirmation rules
  * Workflow to remove the duplicate-candidate label on user activity

* **Documentation**
  * Added docs describing the duplicate-detection and auto-close behaviors and markers

* **Tests**
  * Unit tests covering detection, normalization, polling, reactions, and auto-close logic

* **Chores**
  * PR review workflow now also triggers on code updates (synchronize) and relaxes token fallback rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->